### PR TITLE
Added unit-tests for division

### DIFF
--- a/prolog/interval.pl
+++ b/prolog/interval.pl
@@ -206,24 +206,17 @@ int_hook(_..._ =:= _..._, false, _).
 %
 int_hook((/)/2).
 int_hook(A1...A2 / B1...B2, Res, _) :-
-    (
-        strictneg(A1, A2);
-        strictpos(A1, A2)
-    ),
-    mixed(B1,B2),
+    !,
     div(A1...A2, B1...B2, Res).
 
-int_hook(A1...A2 / B1...B2, Res, _) :-
-    div(A1...A2, B1...B2, Res),
-    !.
-
 int_hook(A1...A2 / B, Res, _) :-
-    div(A1...A2, B...B, Res),
-    !.
+    !,
+    div(A1...A2, B...B, Res).
 
 int_hook(A / B1...B2, Res, _) :-
-    div(A...A, B1...B2, Res),
-    !.
+    !,
+    div(A...A, B1...B2, Res).
+
 
 int_hook(A / B, Res, _) :-
     Res is A / B.

--- a/prolog/interval.pl
+++ b/prolog/interval.pl
@@ -206,13 +206,24 @@ int_hook(_..._ =:= _..._, false, _).
 %
 int_hook((/)/2).
 int_hook(A1...A2 / B1...B2, Res, _) :-
+    (
+        strictneg(A1, A2);
+        strictpos(A1, A2)
+    ),
+    mixed(B1,B2),
     div(A1...A2, B1...B2, Res).
 
+int_hook(A1...A2 / B1...B2, Res, _) :-
+    div(A1...A2, B1...B2, Res),
+    !.
+
 int_hook(A1...A2 / B, Res, _) :-
-    div(A1...A2, B...B, Res).
+    div(A1...A2, B...B, Res),
+    !.
 
 int_hook(A / B1...B2, Res, _) :-
-    div(A...A, B1...B2, Res).
+    div(A...A, B1...B2, Res),
+    !.
 
 int_hook(A / B, Res, _) :-
     Res is A / B.

--- a/test/test_interval.pl
+++ b/test/test_interval.pl
@@ -30,189 +30,196 @@ test(=<) :-
 test(dividend_strictpos_divisor_zeropos) :-
     A = 1...2,
     B = 0...2,
-    once(interval(A / B, L...U)),
+    interval(A / B, L...U),
     L is 0.5,
     U is 1.0Inf.
 
 test(dividend_strictpos_divisor_positive) :-
     A = 1...2,
     B = 1...2,
-    once(interval(A / B, L...U)),
+    interval(A / B, L...U),
     L is 0.5,
     U is 2.
 
 test(dividend_zeropos_divisor_zeropos) :-
     A = 0...2,
     B = 0...1,
-    once(interval(A / B, L...U)),
+    interval(A / B, L...U),
     L is 0.0,
     U is 1.0Inf.
 
 test(dividend_zeropos_divisor_positive) :-
     A = 0...2,
     B = 1...2,
-    once(interval(A / B, L...U)),
+    interval(A / B, L...U),
     L is 0.0,
     U is 2.
 
 test(dividend_mixed_divisor_zeropos) :-
     A = -1...1,
     B = 0...1,
-    once(interval(A / B, L...U)),
+    interval(A / B, L...U),
     L is -1.0Inf,
     U is 1.0Inf.
 
 test(dividend_mixed_divisor_positive) :-
     A = -1...1,
     B = 2...4,
-    once(interval(A / B, L...U)),
+    interval(A / B, L...U),
     L is -0.5,
     U is 0.5.
 
 test(dividend_zeroneg_divisor_zeropos) :-
     A = -1...0,
     B = 0...1,
-    once(interval(A / B, L...U)),
+    interval(A / B, L...U),
     L is -1.0Inf,
     U is 0.0.
 
 test(dividend_zeroneg_divisor_positive) :-
     A = -1...0,
     B = 2...3,
-    once(interval(A / B, L...U)),
+    interval(A / B, L...U),
     L is -0.5,
     U is 0.0.
 
 test(dividend_strictneg_divisor_zeropos) :-
-    A = ...(-2,-1),
+    A = -2... -1,
     B = 0...2,
-    once(interval(A / B, L...U)),
+    interval(A / B, L...U),
     L is -1.0Inf,
     U is -0.5.
 
 test(dividend_strictneg_divisor_positive) :-
-    A = ...(-2,-1),
+    A = -2... -1,
     B = 2...4,
-    once(interval(A / B, L...U)),
+    interval(A / B, L...U),
     L is -1,
     U is -0.25.
 
 test(dividend_strictpos_divisor_mixed) :-
     A = 1...2,
     B = -2...1,
-    once(interval(A / B, L...U)), 
-    L is -1.0Inf,
-    U is -0.5.
+    setof(Res, interval(A / B, Res), Results), 
+    L1 is -1.0Inf,
+    U1 is -0.5,
+    L2 is 1,
+    U2 is 1.0Inf,
+    Results = [L1...U1, L2...U2].
+    
 
 test(dividend_zeropos_divisor_mixed) :-
     A = 0...1,
     B = -1...1,
-    once(interval(A / B, L...U)),
+    interval(A / B, L...U),
     L is -1.0Inf,
     U is 1.0Inf.
 
 test(dividend_mixed_divisor_mixed) :-
     A = -1...1,
     B = -2...2,
-    once(interval(A / B, L...U)),
+    interval(A / B, L...U),
     L is -1.0Inf,
     U is 1.0Inf.
 
 test(dividend_zeroneg_divisor_mixed) :-
     A = -1...0,
     B = -2...2,
-    once(interval(A / B, L...U)),
+    interval(A / B, L...U),
     L is -1.0Inf,
     U is 1.0Inf.
 
 test(dividend_strictneg_divisor_mixed) :-
-    A = ...(-2,-1),
+    A = -2... -1,
     B = -2...2,
-    once(interval(A / B, L...U)),
-    L is -1.0Inf,
-    U is -0.5.
+    setof(Res, interval(A / B, Res), Results), 
+    L1 is -1.0Inf,
+    U1 is -0.5,
+    L2 is 0.5,
+    U2 is 1.0Inf,
+    Results = [L1...U1, L2...U2].
 
 test(dividend_strictpos_divisor_zeroneg) :-
     A = 1...2,
     B = -2...0.0,
-    once(interval(A / B, L...U)),
+    interval(A / B, L...U),
     L is -1.0Inf,
     U is -0.5.
 
 test(dividend_strictpos_divisor_negative) :-
     A = 1...2,
-    B = ...(-2,-1),
-    once(interval(A / B, L...U)),
+    B = -2... -1,
+    interval(A / B, L...U),
     L is -2,
     U is -0.5.
 
 test(dividend_zeropos_divisor_zeroneg) :-
     A = 0...1,
     B = -1...0.0,
-    once(interval(A / B, L...U)),
+    interval(A / B, L...U),
     L is -1.0Inf,
     U is 0.0.
 
 test(dividend_zeropos_divisor_negative) :-
     A = 0...1,
-    B = ...(-2,-1),
-    once(interval(A / B, L...U)),
+    B = -2... -1,
+    interval(A / B, L...U),
     L is -1,
     U is 0.0.
 
 test(dividend_mixed_divisor_zeroneg) :-
     A = -1...2,
     B = -2...0.0,
-    once(interval(A / B, L...U)),
+    interval(A / B, L...U),
     L is -1.0Inf,
     U is 1.0Inf.
 
 test(dividend_mixed_divisor_negative) :-
     A = -1...2,
-    B = ...(-2,-1),
-    once(interval(A / B, L...U)),
+    B = -2... -1,
+    interval(A / B, L...U),
     L is -2,
     U is 1.
 
 test(dividend_zeroneg_divisor_zeroneg) :-
     A = -1...0,
     B = -2...0.0,
-    once(interval(A / B, L...U)),
+    interval(A / B, L...U),
     L is 0.0,
     U is 1.0Inf.
 
 test(dividend_zeroneg_divisor_negative) :-
     A = -1...0,
-    B = ...(-2,-1),
-    once(interval(A / B, L...U)),
+    B = -2... -1,
+    interval(A / B, L...U),
     L is 0.0,
     U is 1.
 
 test(dividend_strictneg_divisor_zeroneg) :-
-    A = ...(-2,-1),
+    A = -2... -1,
     B = -2...0.0,
-    once(interval(A / B, L...U)),
+    interval(A / B, L...U),
     L is 0.5,
     U is 1.0Inf.
 
 test(dividend_strictneg_divisor_negative) :-
-    A = ...(-2,-1),
-    B = ...(-2,-1),
-    once(interval(A / B, L...U)),
+    A = -2... -1,
+    B = -2... -1,
+    interval(A / B, L...U),
     L is 0.5,
     U is 2.
 
 test(dividend_interval_divisor_number) :-
-    A = ...(-2,-1),
+    A = -2... -1,
     B is 2,
-    once(interval(A / B, L...U)),
+   interval(A / B, L...U),
     L is -1,
     U is -0.5.
 
 test(dividend_number_divisor_interval) :-
     A = 2,
-    B = ...(-2,-1),
-    once(interval(A / B, L...U)),
+    B = -2... -1,
+    interval(A / B, L...U),
     L is -2,
     U is -1.
 

--- a/test/test_interval.pl
+++ b/test/test_interval.pl
@@ -9,7 +9,7 @@
 :- set_prolog_flag(float_zero_div, infinity).
 
 test_interval :-
-    run_tests([comparison, sqrt, abs, round]).
+    run_tests([comparison, division, sqrt, abs, round]).
 
 :- begin_tests(comparison).
 
@@ -24,6 +24,205 @@ test(=<) :-
     interval(A =< B, true).
 
 :- end_tests(comparison).
+
+:- begin_tests(division).
+
+test(dividend_strictpos_divisor_zeropos) :-
+    A = 1...2,
+    B = 0...2,
+    once(interval(A / B, L...U)),
+    L is 0.5,
+    U is 1.0Inf.
+
+test(dividend_strictpos_divisor_positive) :-
+    A = 1...2,
+    B = 1...2,
+    once(interval(A / B, L...U)),
+    L is 0.5,
+    U is 2.
+
+test(dividend_zeropos_divisor_zeropos) :-
+    A = 0...2,
+    B = 0...1,
+    once(interval(A / B, L...U)),
+    L is 0.0,
+    U is 1.0Inf.
+
+test(dividend_zeropos_divisor_positive) :-
+    A = 0...2,
+    B = 1...2,
+    once(interval(A / B, L...U)),
+    L is 0.0,
+    U is 2.
+
+test(dividend_mixed_divisor_zeropos) :-
+    A = -1...1,
+    B = 0...1,
+    once(interval(A / B, L...U)),
+    L is -1.0Inf,
+    U is 1.0Inf.
+
+test(dividend_mixed_divisor_positive) :-
+    A = -1...1,
+    B = 2...4,
+    once(interval(A / B, L...U)),
+    L is -0.5,
+    U is 0.5.
+
+test(dividend_zeroneg_divisor_zeropos) :-
+    A = -1...0,
+    B = 0...1,
+    once(interval(A / B, L...U)),
+    L is -1.0Inf,
+    U is 0.0.
+
+test(dividend_zeroneg_divisor_positive) :-
+    A = -1...0,
+    B = 2...3,
+    once(interval(A / B, L...U)),
+    L is -0.5,
+    U is 0.0.
+
+test(dividend_strictneg_divisor_zeropos) :-
+    A = ...(-2,-1),
+    B = 0...2,
+    once(interval(A / B, L...U)),
+    L is -1.0Inf,
+    U is -0.5.
+
+test(dividend_strictneg_divisor_positive) :-
+    A = ...(-2,-1),
+    B = 2...4,
+    once(interval(A / B, L...U)),
+    L is -1,
+    U is -0.25.
+
+test(dividend_strictpos_divisor_mixed) :-
+    A = 1...2,
+    B = -2...1,
+    once(interval(A / B, L...U)), 
+    L is -1.0Inf,
+    U is -0.5.
+
+test(dividend_zeropos_divisor_mixed) :-
+    A = 0...1,
+    B = -1...1,
+    once(interval(A / B, L...U)),
+    L is -1.0Inf,
+    U is 1.0Inf.
+
+test(dividend_mixed_divisor_mixed) :-
+    A = -1...1,
+    B = -2...2,
+    once(interval(A / B, L...U)),
+    L is -1.0Inf,
+    U is 1.0Inf.
+
+test(dividend_zeroneg_divisor_mixed) :-
+    A = -1...0,
+    B = -2...2,
+    once(interval(A / B, L...U)),
+    L is -1.0Inf,
+    U is 1.0Inf.
+
+test(dividend_strictneg_divisor_mixed) :-
+    A = ...(-2,-1),
+    B = -2...2,
+    once(interval(A / B, L...U)),
+    L is -1.0Inf,
+    U is -0.5.
+
+test(dividend_strictpos_divisor_zeroneg) :-
+    A = 1...2,
+    B = -2...0.0,
+    once(interval(A / B, L...U)),
+    L is -1.0Inf,
+    U is -0.5.
+
+test(dividend_strictpos_divisor_negative) :-
+    A = 1...2,
+    B = ...(-2,-1),
+    once(interval(A / B, L...U)),
+    L is -2,
+    U is -0.5.
+
+test(dividend_zeropos_divisor_zeroneg) :-
+    A = 0...1,
+    B = -1...0.0,
+    once(interval(A / B, L...U)),
+    L is -1.0Inf,
+    U is 0.0.
+
+test(dividend_zeropos_divisor_negative) :-
+    A = 0...1,
+    B = ...(-2,-1),
+    once(interval(A / B, L...U)),
+    L is -1,
+    U is 0.0.
+
+test(dividend_mixed_divisor_zeroneg) :-
+    A = -1...2,
+    B = -2...0.0,
+    once(interval(A / B, L...U)),
+    L is -1.0Inf,
+    U is 1.0Inf.
+
+test(dividend_mixed_divisor_negative) :-
+    A = -1...2,
+    B = ...(-2,-1),
+    once(interval(A / B, L...U)),
+    L is -2,
+    U is 1.
+
+test(dividend_zeroneg_divisor_zeroneg) :-
+    A = -1...0,
+    B = -2...0.0,
+    once(interval(A / B, L...U)),
+    L is 0.0,
+    U is 1.0Inf.
+
+test(dividend_zeroneg_divisor_negative) :-
+    A = -1...0,
+    B = ...(-2,-1),
+    once(interval(A / B, L...U)),
+    L is 0.0,
+    U is 1.
+
+test(dividend_strictneg_divisor_zeroneg) :-
+    A = ...(-2,-1),
+    B = -2...0.0,
+    once(interval(A / B, L...U)),
+    L is 0.5,
+    U is 1.0Inf.
+
+test(dividend_strictneg_divisor_negative) :-
+    A = ...(-2,-1),
+    B = ...(-2,-1),
+    once(interval(A / B, L...U)),
+    L is 0.5,
+    U is 2.
+
+test(dividend_interval_divisor_number) :-
+    A = ...(-2,-1),
+    B is 2,
+    once(interval(A / B, L...U)),
+    L is -1,
+    U is -0.5.
+
+test(dividend_number_divisor_interval) :-
+    A = 2,
+    B = ...(-2,-1),
+    once(interval(A / B, L...U)),
+    L is -2,
+    U is -1.
+
+test(dividend_number_divisor_number) :-
+    A = 1,
+    B = 2,
+    interval(A / B, Res),
+    Res is 0.5.
+
+:- end_tests(division).
 
 :- begin_tests(sqrt).
 


### PR DESCRIPTION
I've added unit tests to 'interval' for the division operation.

<br>

![image](https://github.com/mgondan/interval/assets/149394139/8b8e7dbb-efca-4f06-9b2d-9ac48c4d02a7)

<br>

I used once/1 in every test to avoid this warning:

<br>

![image](https://github.com/mgondan/interval/assets/149394139/20f5216c-0f60-4c18-939a-9931a77b74b0)

<br>

Another option would have been to add a cut in the respective predicates...

I also tried to test the predicates with two solutions, such as this one:

<br>

![image](https://github.com/mgondan/interval/assets/149394139/d634b187-e084-4b68-8d8c-eaf454b6fe43)

<br>


with setof/3, but it did not work. The issue seems to be a more general one related to the fact that right now Prolog does not backtrack to find multiple solutions, even with minimal examples. 

For example, I have this module:

:- module(debug, [f/1]).

f(1).
f(2).


and I get only one solution:
?- f(X).
X = 1 .

?- 

It is very strange...

<br>

<br>

I further added two test for 'mcint' (frac and dfrac) and tried to fix the other two (omit_left and omit_right), which did not pass. 
The result of 
?- interval(omit_left(11...12 - 20...21), Res).
is
Res = -8.

and not an interval:
L > 19.9999,
L < 20.0001,
U > 20.9999,
U < 21.0001.

as defined in the  test.
But the result in test is the expected one, right?






