### PR TITLE
Renamed 'int_hook_register/2' to 'int_hook/2'

### DIFF
--- a/prolog/interval.pl
+++ b/prolog/interval.pl
@@ -1,6 +1,6 @@
 :- module(interval, [interval/2, interval/3, op(150, xfx, ...)]).
 
-:- multifile int_hook_register/2.
+:- multifile int_hook/2.
 :- multifile int_hook/3.
 :- multifile eval_hook/2.
 :- multifile mono/2.
@@ -38,9 +38,8 @@ interval(L...U, Res, _)
 interval(Expr, Res, Opt),
     compound(Expr),
     compound_name_arity(Expr, Name, Arity),
-    int_hook_register(Name/Arity, Opt),
-    option(evaluate(Eval), Opt, true),
-    Eval = true
+    int_hook(Name/Arity, Opt),
+    option(evaluate(true), Opt, true)
  => compound_name_arguments(Expr, Name, Args),
     maplist(interval_(Opt), Args, Args1),
     compound_name_arguments(Expr1, Name, Args1),
@@ -50,7 +49,7 @@ interval(Expr, Res, Opt),
 interval(Expr, Res, Opt),
     compound(Expr),
     compound_name_arity(Expr, Name, Arity),
-    int_hook_register(Name/Arity, _Opt)
+    int_hook(Name/Arity, _Opt)
  => int_hook(Expr, Res, Opt).
 
 %
@@ -163,7 +162,7 @@ eval(X, Res)
 %
 % Comparison
 %
-int_hook_register((<)/2, []).
+int_hook((<)/2, []).
 int_hook(_...A2 < B1..._, Res, _) :-
     A2 < B1,
     !,
@@ -171,7 +170,7 @@ int_hook(_...A2 < B1..._, Res, _) :-
 
 int_hook(_..._ < _..._, false, _).
 
-int_hook_register((=<)/2, []).
+int_hook((=<)/2, []).
 int_hook(A1..._ =< _...B2, Res, _) :-
     A1 =< B2,
     !,
@@ -179,7 +178,7 @@ int_hook(A1..._ =< _...B2, Res, _) :-
 
 int_hook(_..._ =< _..._, false, _).
 
-int_hook_register((>)/2, []).
+int_hook((>)/2, []).
 int_hook(A1..._ > _...B2, Res, _) :-
     A1 > B2,
     !,
@@ -187,7 +186,7 @@ int_hook(A1..._ > _...B2, Res, _) :-
 
 int_hook(_..._ > _..._, false, _).
 
-int_hook_register((>=)/2, []).
+int_hook((>=)/2, []).
 int_hook(_...A2 >= B1..._, Res, _) :-
     A2 >= B1,
     !,
@@ -214,7 +213,7 @@ int_hook(_..._ =:= _..._, false, _).
 %
 % Division
 %
-int_hook_register((/)/2, []).
+int_hook((/)/2, []).
 int_hook(A1...A2 / B1...B2, Res, _) :-
     !,
     div(A1...A2, B1...B2, Res).
@@ -437,7 +436,7 @@ div(A...B, C...D, Res),
 %
 mono(sqrt/1, [+]).
 
-int_hook_register(sqrt1/1, []).
+int_hook(sqrt1/1, []).
 int_hook(sqrt1(A...B), Res, _) :-
     strictneg(A, B),
     !,
@@ -459,7 +458,7 @@ int_hook(sqrt1(X), Res, Opt) :-
 %
 % Absolute value
 %
-int_hook_register(abs/1, []).
+int_hook(abs/1, []).
 int_hook(abs(A...B), Res, _) :-
     positive(A, B),
     !,
@@ -482,7 +481,7 @@ int_hook(abs(A...B), Res, _) :-
 %
 % round interval
 %
-int_hook_register(round/1, []).
+int_hook(round/1, []).
 int_hook(round(A...B), Res, Opt) :-
     option(digit(Dig), Opt, 2),
     eval(floor(A, Dig), A1),

--- a/prolog/mcclass.pl
+++ b/prolog/mcclass.pl
@@ -10,26 +10,26 @@ interval:int_hook(frac/2).
 interval:int_hook(frac(A, B), Res, Opt) :-
     interval(A / B, Res, Opt).
 
-interval:int_hook_register(dfrac/2, []).
+interval:int_hook(dfrac/2, []).
 interval:int_hook(dfrac(A, B), Res, Opt) :-
     interval(A / B, Res), Opt.
 
 %
 % Reasonable number of digits
 %
-interval:int_hook_register(tstat/1, []).
+interval:int_hook(tstat/1, []).
 interval:int_hook(tstat(A), Res, Opt) :-
     interval(A, Res, [digits(2) | Opt]).
 
 %
 % Forget parts of an expression
 %
-interval:int_hook_register(omit_left/1, [evaluate(false)]).
+interval:int_hook(omit_left/1, [evaluate(false)]).
 interval:int_hook(omit_left(Expr), Res, Opt) :-
     Expr =.. [_Op, _L, R],
     interval(R, Res, Opt).
 
-interval:int_hook_register(omit_right/1, [evaluate(false)]).
+interval:int_hook(omit_right/1, [evaluate(false)]).
 interval:int_hook(omit_right(Expr), Res, Opt) :-
     Expr =.. [_Op, L, _R],
     interval(L, Res, Opt).

--- a/prolog/rint.pl
+++ b/prolog/rint.pl
@@ -8,7 +8,7 @@
 %
 % Skip R vectors
 %
-interval:int_hook_register((:)/2, []).
+interval:int_hook((:)/2, []).
 interval:int_hook(A:B, A:B, _).
 
 %
@@ -33,7 +33,7 @@ r_hook(false).
 %
 % Binomial distribution
 %
-interval:int_hook_register(pbinom/4, []).
+interval:int_hook(pbinom/4, []).
 
 % lower tail
 interval:int_hook(pbinom(X, N, P, true), Res, Opt) :-
@@ -52,7 +52,7 @@ interval:mono(pbinom1/3, [-, +, +]).
 %
 % Quantile function
 %
-interval:int_hook_register(qbinom/4, []).
+interval:int_hook(qbinom/4, []).
 
 % lower tail
 interval:int_hook(qbinom(Alpha, N, P, true), Res, Opt) :-
@@ -71,7 +71,7 @@ interval:mono(qbinom1/3, [-, +, +]).
 %
 % Density
 %
-interval:int_hook_register(dbinom/3, []).
+interval:int_hook(dbinom/3, []).
 
 % left to X / N
 interval:int_hook(dbinom(X1...X2, N1...N2, P1...P2), Res, Opt) :-
@@ -102,7 +102,7 @@ interval:int_hook(dbinom(X1...X2, N1...N2, P1...P2), Res, _) :-
 r_hook(pnorm0/1).
 interval:mono(pnorm0/1, [+]).
 
-interval:int_hook_register(pnorm/3, []).
+interval:int_hook(pnorm/3, []).
 interval:int_hook(pnorm(X, Mu, Sigma), Res, Opt) :-
      interval((X - Mu)/Sigma, Z, Opt),
      interval(pnorm0(Z), Res, Opt).
@@ -113,7 +113,7 @@ interval:int_hook(pnorm(X, Mu, Sigma), Res, Opt) :-
 r_hook(qnorm0/1).
 interval:mono(qnorm0/1, [+]).
 
-interval:int_hook_register(qnorm/3, []).
+interval:int_hook(qnorm/3, []).
 interval:int_hook(qnorm(P, Mu, Sigma), Res, Opt) :-
      interval(qnorm0(P), Z, Opt),
      interval(Mu + Z * Sigma, Res, Opt).
@@ -127,12 +127,12 @@ interval:mono(dnorm1/1, [+]).
 r_hook(dnorm2/1).
 interval:mono(dnorm2/1, [-]).
 
-interval:int_hook_register(dnorm/3, []).
+interval:int_hook(dnorm/3, []).
 interval:int_hook(dnorm(X, Mu, Sigma), Res, Opt) :-
     interval((X - Mu)/Sigma, Z, Opt),
     interval(1/Sigma * dnorm0(Z), Res, Opt).
 
-interval:int_hook_register(dnorm0/1, []).
+interval:int_hook(dnorm0/1, []).
 interval:int_hook(dnorm0(A...B), Res, Opt) :-
     B =< 0,
     !,


### PR DESCRIPTION
Renamed the predicate and simplified the Eval.

BTW, is it normal that the automatic tests fail?