### PR TITLE
Added power and tests

### DIFF
--- a/prolog/mcclass.pl
+++ b/prolog/mcclass.pl
@@ -82,14 +82,9 @@ available(A, Res),
 available(A ... B, Res)
 => available(A, A1),
    available(B, B1),
-   eval(A1, B1, Res).
+   interval:eval(A1, B1, Res).
 
 available(ci(A, B), Res)
 => available(A, A1),
    available(B, B1),
-   eval(A1, B1, Res).
-
-% For convenience
-eval(Expr1, Expr2, L ... U) :-
-    interval:eval(Expr1, L),
-    interval:eval(Expr2, U).
+   interval:eval(A1, B1, Res).

--- a/test/test_interval.pl
+++ b/test/test_interval.pl
@@ -9,7 +9,7 @@
 :- set_prolog_flag(float_zero_div, infinity).
 
 test_interval :-
-    run_tests([comparison, division, sqrt, abs, round]).
+    run_tests([comparison, division, sqrt, power, abs, round]).
 
 :- begin_tests(comparison).
 
@@ -299,6 +299,52 @@ test(sqrt10) :-
     X = 1.5NaN.
 
 :- end_tests(sqrt).
+
+:- begin_tests(power).
+
+test(power_pos_base_even_expon) :-
+    Base = 2...3,
+    Exp = 2,
+    interval(Base ^ Exp, L...U),
+    L is 4,
+    U is 9.
+
+test(power_pos_base_odd_expon) :-
+    Base = 2...3,
+    Exp = 3,
+    interval(Base ^ Exp, L...U),
+    L is 8,
+    U is 27.
+
+test(power_neg_base_even_expon) :-
+    Base = -3... -2,
+    Exp = 2,
+    interval(Base ^ Exp, L...U),
+    L is 4,
+    U is 9.
+
+test(power_neg_base_odd_expon) :-
+    Base = -3... -2,
+    Exp = 3,
+    interval(Base ^ Exp, L...U),
+    L is -27,
+    U is -8.
+
+test(power_mixed_base_even_expon) :-
+    Base = -3...2,
+    Exp = 2,
+    interval(Base ^ Exp, L...U),
+    L is 0,
+    U is 9.
+
+test(power_mixed_base_odd_expon) :-
+    Base = -3...2,
+    Exp = 3,
+    interval(Base ^ Exp, L...U),
+    L is -27,
+    U is 8.
+
+:- end_tests(power).
 
 :- begin_tests(abs).
 


### PR DESCRIPTION
Added power function defined for exponent being a natural number.

In the general case, the result interval is L^Exp ... U^Exp, except for two cases.

- When the base is negative and the exponent even, then the bounds need to be reversed: -3 ... -2 ^ 2 = 4 ... 9

- When the base is mixed and the exponent even, then the lower bound is 0 and the upper bound the maximum of the elevated base's bounds: -3 ... 2 ^ 2 = 0 ... 9