### PR TITLE
Fixed test_mcclass

### DIFF
--- a/prolog/interval.pl
+++ b/prolog/interval.pl
@@ -58,9 +58,11 @@ interval(atomic(A), Res)
 %    Args specify the type of the arguments, ... for interval and atomic for numbers.
 % 2. Calculate result with interval:pred_name(Args, Res)
 %    Args are the argument types as defined in the hook with variable names.
-% 
+% 3. Define interval:int_hook_opt(Name, [evaluate(false)]). to skip evaluation of arguments.
 %
 % see below example for (/)/2.
+
+% Skipping evaluation of arguments
 interval(Expr, Res),
     compound(Expr),
     compound_name_arguments(Expr, Name, Args),
@@ -77,7 +79,6 @@ instantiate2(A, atomic(_), atomic(A)).
 instantiate2(L...U, _..._, L...U).
 instantiate2(A, expr(_), expr(A)).
 instantiate2(ci(A, B), ci(_, _), ci(A, B)).
-
 
 interval(Expr, Res),
     compound(Expr),
@@ -278,7 +279,6 @@ div4(atomic(A), atomic(B), Res) :-
 
 div4(atomic(A), atomic(B), atomic(Res)) :-
     Res is A / B.
-
 
 % Hickey Figure 1
 mixed(L, U) :-

--- a/prolog/mcclass.pl
+++ b/prolog/mcclass.pl
@@ -36,23 +36,17 @@ interval:pval(A...B, Res) :-
 %
 % Forget parts of an expression
 %
-/*interval:int_hook(omit_left/1, [evaluate(false)]).
-interval:int_hook(omit_left(Expr), Res, Opt) :-
+interval:int_hook(omit_left, omit_left(expr)).
+interval:int_hook_opt(omit_left, [evaluate(false)]).
+interval:omit_left(expr(Expr), Res) :-
     Expr =.. [_Op, _L, R],
-    interval(R, Res, Opt).*/
-interval:int_hook(omit_left, omit_left(_)).
-interval:omit_left(Expr, Res) :-
-    Expr =.. [_Op, _L, R],
-    interval(R, Res).
+    Res = R.
 
-/*interval:int_hook(omit_right/1, [evaluate(false)]).
-interval:int_hook(omit_right(Expr), Res, Opt) :-
+interval:int_hook(omit_right, omit_right(expr)).
+interval:int_hook_opt(omit_right, [evaluate(false)]).
+interval:omit_right(expr(Expr), Res) :-
     Expr =.. [_Op, L, _R],
-    interval(L, Res, Opt).*/
-interval:int_hook(omit_right, omit_right(_)).
-interval:omit_right(Expr, Res) :-
-    Expr =.. [_Op, L, _R],
-    interval(L, Res).
+    Res = L.
 
 %
 % Multiply
@@ -66,11 +60,10 @@ interval:dot(A, B, Res) :-
 %
 interval:int_hook(available, avail1(atomic)).
 interval:avail1(atomic(A), Res) :-
-    avail2(A, _),
+    avail2(atomic(A), _),
     !,
     Res = true;
     Res = false.
-
 
 avail2(atomic(A), Res),
    integer(A)

--- a/test/test_interval.pl
+++ b/test/test_interval.pl
@@ -267,7 +267,8 @@ test(dividend_number_divisor_number) :-
     A = 1,
     B = 2,
     interval(atomic(A) / atomic(B), Res),
-    Res is 0.5.
+    Res is 0.5,
+    !.
 
 :- end_tests(division).
 

--- a/test/test_mcclass.pl
+++ b/test/test_mcclass.pl
@@ -27,42 +27,33 @@ test(dfrac) :-
 
 :- begin_tests(number_digit).
 
-% ToDo: adjust expected results after implementation of option evaluation 
 test(tstat) :-
     A = 1...5,
     B = 3...6,
     interval(tstat(A / B), L...U),
-    L > 0.1666,
-    L < 0.1667,
-    U > 1.6666,
-    U < 1.6667.
+    L is 0.16,
+    U is 1.67.
 
 test(hdrs) :-
     A = 1...5,
     B = 3...6,
     interval(hdrs(A / B), L...U),
-    L > 0.1666,
-    L < 0.1667,
-    U > 1.6666,
-    U < 1.6667.
+    L is 0.1,
+    U is 1.7.
 
 test(chi2ratio) :-
     A = 1...5,
     B = 3...6,
     interval(chi2ratio(A / B), L...U),
-    L > 0.1666,
-    L < 0.1667,
-    U > 1.6666,
-    U < 1.6667.
+    L is 0.16,
+    U is 1.67.
 
 test(pval) :-
     A = 1...5,
     B = 3...6,
     interval(pval(A / B), L...U),
-    L > 0.1666,
-    L < 0.1667,
-    U > 1.6666,
-    U < 1.6667.
+    L is 0.166,
+    U is 1.667.
 
 :- end_tests(number_digit).
 


### PR DESCRIPTION
Changes to make the tests of mcclass work. 
This implied adding int_hook_opt/2 to skip evaluation in predicates 'omit_left' and 'omit_right'. 