### PR TITLE
Adjusted instantiate/2 and added tests for plus/2

### DIFF
--- a/prolog/interval.pl
+++ b/prolog/interval.pl
@@ -106,8 +106,16 @@ interval_(Expr, Res, Flags),
 interval__(Flags, A, Res) :-
     interval_(A, Res, Flags).
 
-instantiate(atomic, atomic(_)).
-instantiate(..., _..._).
+instantiate(A, Res), 
+    A = atomic
+ => Res = atomic(_).
+
+instantiate(A, Res), 
+    A = ...
+ => Res = _..._.
+
+instantiate(A, Res) 
+ => Res = A.
 
 % Skipping evaluation of arguments
 interval_(Expr, Res, Flags),
@@ -220,7 +228,7 @@ eval(X, Res)
 %
 % Comparison
 %
-int_hook(<, less1(atomic, atomic), atomic, []).
+int_hook(<, less1(atomic, atomic), _, []).
 
 less1(atomic(A), atomic(B), Res, _Flags) :-
     A < B,
@@ -231,7 +239,7 @@ less1(atomic(_) < atomic(_), Res, _Flags) :-
     !,
     Res = false.
 
-int_hook(<, less2(..., ...), atomic, []).
+int_hook(<, less2(..., ...), _, []).
 
 less2(_...A2, B1..._, Res, _Flags) :-
     A2 < B1,
@@ -240,7 +248,7 @@ less2(_...A2, B1..._, Res, _Flags) :-
 
 less2(_..._, _..._, false2, _Flags).
 
-int_hook(=<, less_eq(..., ...), atomic, []).
+int_hook(=<, less_eq(..., ...), _, []).
 
 less_eq(A1..._, _...B2, Res, _Flags) :-
     A1 =< B2,
@@ -249,7 +257,7 @@ less_eq(A1..._, _...B2, Res, _Flags) :-
 
 less_eq(_..._, _..._, false, _Flags).
 
-int_hook(>, great(..., ...), atomic, []).
+int_hook(>, great(..., ...), _, []).
 great(A1..._, _...B2, Res, _Flags) :-
     A1 > B2,
     !,
@@ -257,7 +265,7 @@ great(A1..._, _...B2, Res, _Flags) :-
 
 great(_..._, _..._, false, _Flags).
 
-int_hook(>=, great_eq(..., ...), atomic, []).
+int_hook(>=, great_eq(..., ...), _, []).
 great_eq(_...A2, B1..._, Res, _Flags) :-
     A2 >= B1,
     !,
@@ -265,7 +273,7 @@ great_eq(_...A2, B1..._, Res, _Flags) :-
 
 great_eq(_..._, _..._, false, _Flags).
 
-int_hook(=\=, not_eq(..., ...), atomic, []).
+int_hook(=\=, not_eq(..., ...), _, []).
 not_eq(A...B, C...D, Res, Flags) :-
     (   less2(A...B, C...D, true, Flags)
     ;   great(A...B, C...D, true, Flags)
@@ -274,7 +282,7 @@ not_eq(A...B, C...D, Res, Flags) :-
 
 not_eq(_..._, _..._, false, _Flags).
 
-int_hook(=:=, eq(..., ...), atomic, []).
+int_hook(=:=, eq(..., ...), _, []).
 eq(A...B, C...D, Res, Flags) :-
     less_eq(A...B, C...D, true, Flags),
     great_eq(A...B, C...D, true, Flags),

--- a/prolog/mcclass.pl
+++ b/prolog/mcclass.pl
@@ -3,8 +3,17 @@
 :- reexport(interval).
 :- reexport(rint).
 
-interval:int_hook(plus, plus(..., ...), ..., []).
-interval:plus(A, B, Res, Flags) :-
+%
+% Addition (for testing)
+%
+interval:int_hook(plus, plus1(atomic, atomic), atomic, []).
+interval:plus1(atomic(A), atomic(B), atomic(Res), _Flags) :-
+    !,
+    writeln(+),
+    Res is A + B.
+
+interval:int_hook(plus, plus2(..., ...), ..., []).
+interval:plus2(A, B, Res, Flags) :-
     !,
     writeln(+),
     interval:interval_(A + B, Res, Flags).
@@ -66,7 +75,7 @@ interval:dot(A, B, Res, Flags) :-
 %
 % Available: not NA
 %
-interval:int_hook(available, avail1(atomic), atomic, []).
+interval:int_hook(available, avail1(atomic), _, []).
 interval:avail1(atomic(A), Res, _Flags) :-
     avail2(atomic(A), Res),
     !,
@@ -87,7 +96,7 @@ avail2(atomic(A), Res)
 => interval:eval(A, A1),
    avail2(A1, Res).
 
-interval:int_hook(available, avail3(...), atomic, []).
+interval:int_hook(available, avail3(...), _, []).
 interval:avail3(A ... B, Res, _Flags)
 => avail2(atomic(A), A1),
    avail2(atomic(B), B1),
@@ -96,6 +105,6 @@ interval:avail3(A ... B, Res, _Flags)
    Res = true;
    Res = false.
 
-interval:int_hook(=@=, equal1(..., ...), ..., []).
+interval:int_hook(=@=, equal1(..., ...), _, []).
 interval:equal1(A, B, Res, Flags) :-
     interval:interval_(A =:= B, Res, Flags).

--- a/test/test_mcclass.pl
+++ b/test/test_mcclass.pl
@@ -5,7 +5,7 @@
 :- use_module(library(mcclass)).
 
 test_mcclass :-
-    run_tests([fractions, number_digit, omit, multiply, available, equality]).
+    run_tests([fractions, number_digit, omit, multiply, available, equality, plus]).
 
 :- begin_tests(fractions).
 
@@ -123,3 +123,19 @@ test(equality_interval1) :-
     interval(A =@= B, false).
 
 :- end_tests(equality).
+
+:- begin_tests(plus).
+
+test(plus1) :-
+    A = 1,
+    B = 2,
+    interval(plus(A, B), Res),
+    Res is 3.
+
+test(plus2) :-
+    A = 1...2,
+    B = 2...3,
+    interval(plus(A, B), Res),
+    Res = 3...5.
+
+:- end_tests(plus).


### PR DESCRIPTION
I tested your most recent changes about adding the return type in the int_hook.

 I adjusted instantiate/2, because previously, if the int_hook/4 did not specify the return type (e.g., interval:int_hook(frac, frac(_, _), _, [])., instantiate/2 would match the first clause with 'atomic':

instantiate(atomic, atomic(_)).
instantiate(..., _..._).

without backtracking and then it would fail.

Now I changed it to: 

instantiate(A, Res), 
    A = atomic
 => Res = atomic(_).

instantiate(A, Res), 
    A = ...
 => Res = _..._.

instantiate(A, Res) 
 => Res = A.

Another problem problem were the predicates that return a boolean value. Here, the return type was 'atomic', but this did not work. For now, I changed the return type to '_' and it works.

