### PR TITLE
Changed return type and fixed GitHub action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y r-base
+          sudo apt install -y r-base libtirpc-dev
           mkdir -p $HOME/Rlibs 
           R -e "install.packages('RInside', lib='$HOME/Rlibs'); install.packages('Rcpp', lib='$HOME/Rlibs')"
           echo "R_LIBS=$HOME/Rlibs" >> ~/.Renviron

--- a/prolog/interval.pl
+++ b/prolog/interval.pl
@@ -64,6 +64,9 @@ clean(A, A1),
 unwrap(atomic(A), Res)
  => Res = A.
 
+unwrap(A...A, Res)
+ => Res = A.
+
 unwrap(A, Res)
  => Res = A.
 
@@ -621,7 +624,7 @@ abs1(A...B, Res, _Flags) :-
 % round
 %
 int_hook(round, round1(atomic, atomic), atomic, []).
-round1(atomic(A), atomic(Dig), Res, _Flags) :-
+round1(atomic(A), atomic(Dig), atomic(Res), _Flags) :-
     Mul is 10^Dig,
     Res is round(A*Mul) / Mul.
     

--- a/prolog/mcclass.pl
+++ b/prolog/mcclass.pl
@@ -36,21 +36,21 @@ interval:dfrac(A, B, Res, Flags) :-
 %
 % Reasonable number of digits
 %
-interval:int_hook(tstat, tstat(...), ..., []).
-interval:tstat(A...B, Res, Flags) :-
-    interval:interval_(round(A...B, atomic(2)), Res, Flags).
+interval:int_hook(tstat, tstat(_), _, []).
+interval:tstat(A, Res, Flags) :-
+    interval:interval_(round(A, atomic(2)), Res, Flags).
 
-interval:int_hook(hdrs, hdrs(...), ..., []).
-interval:hdrs(A...B, Res, Flags) :-
-    interval:interval_(round(A...B, atomic(1)), Res, Flags).
+interval:int_hook(hdrs, hdrs(_), _, []).
+interval:hdrs(A, Res, Flags) :-
+    interval:interval_(round(A, atomic(1)), Res, Flags).
 
-interval:int_hook(chi2ratio, chi2ratio(...), ..., []).
-interval:chi2ratio(A...B, Res, Flags) :-
-    interval:interval_(round(A...B, atomic(2)), Res, Flags).
+interval:int_hook(chi2ratio, chi2ratio(_), _, []).
+interval:chi2ratio(A, Res, Flags) :-
+    interval:interval_(round(A, atomic(2)), Res, Flags).
 
-interval:int_hook(pval, pval(...), ..., []).
-interval:pval(A...B, Res, Flags) :-
-    interval:interval_(round(A...B, atomic(3)), Res, Flags).
+interval:int_hook(pval, pval(_), _, []).
+interval:pval(A, Res, Flags) :-
+    interval:interval_(round(A, atomic(3)), Res, Flags).
 
 %
 % Forget parts of an expression
@@ -105,6 +105,6 @@ interval:avail3(A ... B, Res, _Flags)
    Res = true;
    Res = false.
 
-interval:int_hook(=@=, equal1(..., ...), _, []).
+interval:int_hook(=@=, equal1(_, _), _, []).
 interval:equal1(A, B, Res, Flags) :-
     interval:interval_(A =:= B, Res, Flags).

--- a/test/test_mcclass.pl
+++ b/test/test_mcclass.pl
@@ -27,28 +27,52 @@ test(dfrac) :-
 
 :- begin_tests(number_digit).
 
-test(tstat) :-
+test(tstat_atomic) :-
+    A = 1,
+    B = 3,
+    interval(tstat(A / B), Res),
+    Res is 0.33.
+
+test(tstat_interval) :-
     A = 1...5,
     B = 3...6,
     interval(tstat(A / B), L...U),
     L is 0.16,
     U is 1.67.
 
-test(hdrs) :-
+test(hdrs_atomic) :-
+    A = 1,
+    B = 3,
+    interval(hdrs(A / B), Res),
+    Res is 0.3.
+
+test(hdrs_interval) :-
     A = 1...5,
     B = 3...6,
     interval(hdrs(A / B), L...U),
     L is 0.1,
     U is 1.7.
 
-test(chi2ratio) :-
+test(chi2ratio_atomic) :-
+    A = 1,
+    B = 3,
+    interval(chi2ratio(A / B), Res),
+    Res is 0.33.
+
+test(chi2ratio_interval) :-
     A = 1...5,
     B = 3...6,
     interval(chi2ratio(A / B), L...U),
     L is 0.16,
     U is 1.67.
 
-test(pval) :-
+test(pval_atomic) :-
+    A = 1,
+    B = 3,
+    interval(pval(A / B), Res),
+    Res is 0.333.
+
+test(pval_interval) :-
     A = 1...5,
     B = 3...6,
     interval(pval(A / B), L...U),
@@ -58,14 +82,25 @@ test(pval) :-
 :- end_tests(number_digit).
 
 :- begin_tests(omit).
+test(omit_right_atomic) :-
+    A = 5,
+    B = 4,
+    interval(omit_right(A - B), Res),
+    Res = A.
 
-test(omit_right) :-
+test(omit_right_interval) :-
     A = 11...12,
     B = 20...21,
     interval(omit_right(A - B), Res),
     Res = A.
 
-test(omit_left) :-
+test(omit_left_atomic) :-
+    A = 5,
+    B = 4,
+    interval(omit_left(A - B), Res),
+    Res = B.
+
+test(omit_left_interval) :-
     A = 11...12,
     B = 20...21,
     interval(omit_left(A - B), Res),
@@ -75,7 +110,13 @@ test(omit_left) :-
 
 :- begin_tests(multiply).
 
-test(dot) :-
+test(dot_atomic) :-
+    A = 2,
+    B = 3,
+    interval(dot(A, B), Res),
+    Res is 6.
+
+test(dot_interval) :-
     A = 2...3,
     B = 3...4,
     interval(dot(A, B), L...U),
@@ -86,7 +127,19 @@ test(dot) :-
 
 :- begin_tests(available).
 
-test(available_int) :-
+test(available_atomic1) :-
+    A = 1,
+    B = 2,
+    interval(available(A + B), Res),
+    Res = true.
+
+test(available_atomic2) :-
+    A = 0,
+    B = 0,
+    interval(available(A / B), Res),
+    Res = false.
+
+test(available_interval) :-
     A = 1...3,
     B = 2...5,
     interval(available(A + B), Res),
@@ -117,7 +170,7 @@ test(equality_interval1) :-
     B = 2...3,
     interval(A =@= B, true).
 
-test(equality_interval1) :-
+test(equality_interval2) :-
     A = 1...2,
     B = 3...4,
     interval(A =@= B, false).


### PR DESCRIPTION
- Changed the return type of tstat/1, hdrs/1, chi2ratio/1, and pval/1 to be accept both atomics and intervals. Updated the unit tests.

- Added the following to interval.pl, so that a result like 2...2 is returned as 2 at the top-level.

```
 unwrap(A...A, Res)
 => Res = A.
```



- Fixed the failing of the GitHub action due to an update of the latest Ubuntu version (from 22.04 to 24.04) 

To fix the warning about "SWI-cpp.h" being obsolete, it would be likely necessary to update the according line in rologpp.cpp in the rologpp repository, so from #include <SWI-cpp.h>  to #include <SWI-cpp2.h>
