### PR TITLE
Update for migration mcclass

### DIFF
--- a/prolog/lib/ci.pl
+++ b/prolog/lib/ci.pl
@@ -1,3 +1,8 @@
+% For mcclass. Todo: change later 
+interval_(A, Res, _Flags),
+    atomic(A)
+ => Res = atomic(A).
+
 interval_(atomic(A), Res, Flags),
     r_hook(A),
     memberchk(topic(_), Flags)

--- a/prolog/lib/core.pl
+++ b/prolog/lib/core.pl
@@ -150,10 +150,6 @@ lower(_, A, L),
     atomic(A)
  => L = A.
 
-lower(_, A, L),
-    A = L1...L1
- => L = L1.
-
 upper(+, _...B, U)
  => U = B.
 
@@ -169,7 +165,3 @@ upper(_, atomic(A), U)
 upper(_, A, U),
     atomic(A)
  => U = A.
- 
-upper(_, A, U),
-    A = U1...U1
- => U = U1.

--- a/prolog/lib/core.pl
+++ b/prolog/lib/core.pl
@@ -150,6 +150,10 @@ lower(_, A, L),
     atomic(A)
  => L = A.
 
+lower(_, A, L),
+    A = L1...L1
+ => L = L1.
+
 upper(+, _...B, U)
  => U = B.
 
@@ -165,3 +169,7 @@ upper(_, atomic(A), U)
 upper(_, A, U),
     atomic(A)
  => U = A.
+ 
+upper(_, A, U),
+    A = U1...U1
+ => U = U1.

--- a/prolog/lib/rint_op.pl
+++ b/prolog/lib/rint_op.pl
@@ -104,6 +104,14 @@ pnorm(X, Mu, Sigma, Res, Flags) :-
      interval_((X - Mu)/Sigma, Z, Flags),
      interval_(pnorm0(Z), Res, Flags).
 
+int_hook(pnorm, pnorm1(...), ..., []).
+pnorm1(Z, Res, Flags) :-
+     interval_(pnorm0(Z), Res, Flags).
+
+int_hook(pnorm, pnorm2(atomic), atomic, []).
+pnorm2(atomic(Z), atomic(Res), Flags) :-
+     eval(pnorm0(Z), Res, Flags).
+
 %
 % Quantile function
 %
@@ -114,6 +122,14 @@ int_hook(qnorm, qnorm(..., ..., ...), ..., []).
 qnorm(P, Mu, Sigma, Res, Flags) :-
      interval_(qnorm0(P), Z, Flags),
      interval_(Mu + Z * Sigma, Res, Flags).
+
+int_hook(qnorm, qnorm1(...), ..., []).
+qnorm1(P, Res, Flags) :-
+     interval_(qnorm0(P), Res, Flags).
+
+int_hook(qnorm, qnorm2(atomic), atomic, []).
+qnorm2(atomic(P), atomic(Res), Flags) :-
+     eval(qnorm0(P), Res, Flags).
 
 %
 % Density

--- a/test/test_rint.pl
+++ b/test/test_rint.pl
@@ -43,13 +43,29 @@ test(pbinom_uppertail) :-
 
 :- begin_tests(normal).
 
-test(pnorm) :-
+test(pnorm1) :-
     interval(pnorm(90...91, 100...101, 10...11), Res),
     equal(Res, 0.1356...0.2067).
 
-test(qnorm) :-
+test(pnorm2) :-
+    interval(pnorm(0.5...0.7), Res),
+    equal(Res, 0.6914...0.7581).
+
+test(pnorm3) :-
+    interval(pnorm(0.5), Res),
+    interval(round(Res, 4), 0.6915).
+
+test(qnorm1) :-
     interval(qnorm(0.6...0.7, 100...101, 10...11), Res),
     equal(Res, 102.5334...106.7685).
+
+test(qnorm2) :-
+    interval(qnorm(0.6...0.7), Res),
+    equal(Res, 0.2533...0.5245).
+
+test(qnorm3) :-
+    interval(qnorm(0.6), Res),
+    interval(round(Res, 4), 0.2533).
 
 test(dnorm_z_neg) :-
     interval(dnorm(90...91, 100...101, 10...11), Res),


### PR DESCRIPTION
Minor additions for migration. 

I also added pnorm/1 and qnorm/1.

For these two I added the variants with atomic numbers. 

```
int_hook(pnorm, pnorm1(...), ..., []).
pnorm1(Z, Res, Flags) :-
     interval_(pnorm0(Z), Res, Flags).

int_hook(pnorm, pnorm2(atomic), atomic, []).
pnorm2(atomic(Z), atomic(Res), Flags) :-
     eval(pnorm0(Z), Res, Flags).
```

Then I was thinking, if it isreasonable to have a clause interval_ at the beginning that checks if the operator is defined with r_hook and only contains atoms and then directly invokes R with eval without passing through all the other interval_ clauses.