### PR TITLE
Updated ^/2 and round/2

### DIFF
--- a/prolog/lib/op.pl
+++ b/prolog/lib/op.pl
@@ -433,12 +433,11 @@ abs1(A...B, Res, _Flags) :-
     Res = L...U.
 
 %
-% round
+% Round
 %
-int_hook(round, round1(atomic, atomic), atomic, []).
-round1(atomic(A), atomic(Dig), atomic(Res), _Flags) :-
-    Mul is 10^Dig,
-    Res is round(A*Mul) / Mul.
+int_hook(round, round1(atomic, atomic), ..., []).
+round1(atomic(A), Dig, Res, Flags) :-
+    round2(A...A, Dig, Res, Flags).
     
 int_hook(round, round2(..., atomic), ..., []).
 round2(A...B, atomic(Dig), Res, _Flags) :-

--- a/prolog/lib/op.pl
+++ b/prolog/lib/op.pl
@@ -390,24 +390,10 @@ pow(A...B, atomic(Exp), Res, _Flags),
  => eval(max(A^Exp, B^Exp), U),
     Res = 0...U.
 
-pow(A...B, atomic(Exp), Res, _Flags),
-    mixed(A, B),
-    natural(Exp)
-    % \+ even(Exp)
- => eval(A^Exp, A1),
-    eval(B^Exp, B1),
-    sort([A1, B1], [L, U]),
-    Res = L...U.
-
-% Positive works with all exponents
+% Positive also works with negative exponents
 pow(L...U, atomic(Exp), Res, _Flags),
     positive(L, U),
-    Exp >= 0
- => eval(L^Exp, U^Exp, Res).
-
-pow(L...U, atomic(Exp), Res, _Flags),
-    positive(L, U)
-    % Exp < 0
+    Exp < 0
  => eval(U^Exp, L^Exp, Res).
 
 % General case

--- a/test/test_interval.pl
+++ b/test/test_interval.pl
@@ -436,6 +436,27 @@ test(round1) :-
     L = 2.71,
     U = 3.15.
 
+test(round2) :-
+    A = 0.333...0.334,
+    Dig = 2,
+    interval(round(A, Dig), L...U),
+    L = 0.33,
+    U = 0.34.
+
+test(round3) :-
+    A = 0.333...0.333,
+    Dig = 2,
+    interval(round(A, Dig), L...U),
+    L = 0.33,
+    U = 0.34.
+
+test(round4) :-
+    A = 0.333,
+    Dig = 2,
+    interval(round(A, Dig), L...U),
+    L = 0.33,
+    U = 0.34.
+
 :- end_tests(round).
 
 :- begin_tests(sin).

--- a/test/test_interval.pl
+++ b/test/test_interval.pl
@@ -384,6 +384,13 @@ test(power_mixed_base_odd_expon) :-
     L is -27,
     U is 8.
 
+test(power_positive_base_neg_expon) :-
+    Base = 2...4,
+    Exp = -2,
+    interval(Base ^ Exp, L...U),
+    L is 0.0625,
+    U is 0.25.
+
 :- end_tests(power).
 
 :- begin_tests(abs).

--- a/test/test_rint.pl
+++ b/test/test_rint.pl
@@ -53,7 +53,9 @@ test(pnorm2) :-
 
 test(pnorm3) :-
     interval(pnorm(0.5), Res),
-    interval(round(Res, 4), 0.6915).
+    interval(round(Res, 4), L...U),
+    L = 0.6914,
+    U = 0.6915.
 
 test(qnorm1) :-
     interval(qnorm(0.6...0.7, 100...101, 10...11), Res),
@@ -65,7 +67,9 @@ test(qnorm2) :-
 
 test(qnorm3) :-
     interval(qnorm(0.6), Res),
-    interval(round(Res, 4), 0.2533).
+    interval(round(Res, 4), L...U),
+    L = 0.2533,
+    U = 0.2534.
 
 test(dnorm_z_neg) :-
     interval(dnorm(90...91, 100...101, 10...11), Res),


### PR DESCRIPTION
### For ^/2:

This should not be necessary:

```
pow(A...B, atomic(Exp), Res, _Flags),
    mixed(A, B),
    natural(Exp)
    % \+ even(Exp)
 => eval(A^Exp, A1),
    eval(B^Exp, B1),
    sort([A1, B1], [L, U]),
    Res = L...U.
```

because, if the interval is mixed, the lower bound will always be negative, the upper one always positive and therefore the lower one will always be smaller than upper one, and this is captured by the general rule:

```
pow(L...U, atomic(Exp), Res, _Flags),
    natural(Exp)
 => eval(L^Exp, U^Exp, Res).
```

This should also be unnecessary:

```
pow(L...U, atomic(Exp), Res, _Flags),
    positive(L, U),
    Exp >= 0
 => eval(L^Exp, U^Exp, Res).
```

as it corresponds to the general rule.



### For round/2:

The behaviour with atomics is now:

```
?- interval(round(0.333, 2), Res).
Res = 0.33...0.34.
```



**The tests that are failing are the ones of rint due to the last update of rolog. I will try to fix that in the next PR.**