### PR TITLE
Fix issue after rolog update

### DIFF
--- a/prolog/lib/rint_op.pl
+++ b/prolog/lib/rint_op.pl
@@ -84,7 +84,7 @@ dbinom(X1...X2, N1...N2, P1...P2, Res, Flags) :-
 
 % otherwise
 dbinom(X1...X2, N1...N2, P1...P2, Res, _Flags) :-
-    r(dbinom2(X1, X2, N1, N2, P1, P2), #(L, U)),
+    r(dbinom2(X1, X2, N1, N2, P1, P2), ##(L, U)),
     Res = L...U.
 
 r_hook(dbinom0/3).


### PR DESCRIPTION
The update of rolog was causing a problem just in this case (one unit-test):
```
?- interval(dbinom(11...12, 20...21, 0.6...0.7), Res).
ERROR: Unhandled exception: Unknown message: "r_eval/2: Cannot unify R object."
```

This small change would fix it (from # to ##):

rint_op.pl
```
dbinom(X1...X2, N1...N2, P1...P2, Res, _Flags) :-
    r(dbinom2(X1, X2, N1, N2, P1, P2), ##(L, U)),
    Res = L...U.
```

or should rather rolog be modified?


