### PR TITLE
Update tests after round/2 change and rolog update fix

### DIFF
--- a/R/r.R
+++ b/R/r.R
@@ -66,10 +66,6 @@ qchisq1 <- function(...) {
 
 dchisq0 <- dchisq1 <-dchisq
 
-atomic <- function(A){
-  return(A)
-}
-
 var_pool <- function(v_A, n_A, v_B, n_B)
 {
   ((n_A - 1) * v_A + (n_B - 1) * v_B) / (n_A + n_B - 2)

--- a/prolog/lib/rint_op.pl
+++ b/prolog/lib/rint_op.pl
@@ -84,7 +84,7 @@ dbinom(X1...X2, N1...N2, P1...P2, Res, Flags) :-
 
 % otherwise
 dbinom(X1...X2, N1...N2, P1...P2, Res, _Flags) :-
-    r(dbinom2(X1, X2, N1, N2, P1, P2), #(L, U)),
+    r(dbinom2(X1, X2, N1, N2, P1, P2), ##(L, U)),
     Res = L...U.
 
 r_hook(dbinom0/3).

--- a/test/test_mcclass.pl
+++ b/test/test_mcclass.pl
@@ -30,8 +30,9 @@ test(dfrac) :-
 test(tstat_atomic) :-
     A = 1,
     B = 3,
-    interval(tstat(A / B), Res),
-    Res is 0.33.
+    interval(tstat(A / B), L...U),
+    L = 0.33,
+    U = 0.34.
 
 test(tstat_interval) :-
     A = 1...5,
@@ -43,8 +44,9 @@ test(tstat_interval) :-
 test(hdrs_atomic) :-
     A = 1,
     B = 3,
-    interval(hdrs(A / B), Res),
-    Res is 0.3.
+    interval(hdrs(A / B), L...U),
+    L = 0.3,
+    U = 0.4.
 
 test(hdrs_interval) :-
     A = 1...5,
@@ -56,8 +58,9 @@ test(hdrs_interval) :-
 test(chi2ratio_atomic) :-
     A = 1,
     B = 3,
-    interval(chi2ratio(A / B), Res),
-    Res is 0.33.
+    interval(chi2ratio(A / B), L...U),
+    L = 0.33,
+    U = 0.34.
 
 test(chi2ratio_interval) :-
     A = 1...5,
@@ -69,8 +72,9 @@ test(chi2ratio_interval) :-
 test(pval_atomic) :-
     A = 1,
     B = 3,
-    interval(pval(A / B), Res),
-    Res is 0.333.
+    interval(pval(A / B), L...U),
+    L = 0.333,
+    U = 0.334.
 
 test(pval_interval) :-
     A = 1...5,
@@ -258,8 +262,10 @@ test(cidiv) :-
 
 test(ciexp) :-
     interval(exp(ci(1, 2)), ci(A, B)),
-    test_mcclass:equal(A, 2.7183),
-    test_mcclass:equal(B, 7.3891).
+    test_mcclass:equal(A, A1),
+    test_mcclass:equal(B, B1),
+    A1 = 2.7182...2.7183,
+    B1 = 7.389...7.3891.
 
 :- end_tests(ci).
 


### PR DESCRIPTION
### 1. 
Updated some other unit-tests after the change to round/2, which I forgot in the last PR.

### 2.
Removed atomic-function from r.R

### 3.
The update of rolog was causing a problem just in this one case (one unit-test):

```
?- interval(dbinom(11...12, 20...21, 0.6...0.7), Res).
ERROR: Unhandled exception: Unknown message: "r_eval/2: Cannot unify R object."
```


This small change would fix it (from # to ##):

rint_op.pl

```
dbinom(X1...X2, N1...N2, P1...P2, Res, _Flags) :-
    r(dbinom2(X1, X2, N1, N2, P1, P2), ##(L, U)),
    Res = L...U.
```

or should rather rolog be modified?

But this fix seems only to work on my local machine, not in tests here in GitHub:

interval(dbinom(11...12, 20...21, 0.6...0.7), Res).
Res = 0.04118282629374998...0.17970578775468932.