### PR TITLE
Update with r_hook/2

### DIFF
--- a/prolog/lib/ci.pl
+++ b/prolog/lib/ci.pl
@@ -3,10 +3,9 @@ interval_(A, Res, _Flags),
     atomic(A)
  => Res = atomic(A).
 
-interval_(atomic(A), Res, Flags),
-    r_hook(A),
-    memberchk(topic(_), Flags)
- => r_mcclass:r_topic(A, Res).
+interval_(atomic(A), Res, _Flags),
+    r_hook(_R, A)
+ => eval(A, Res). 
 
 interval_(C, Res, Flags),
     C = ci(A, B)

--- a/prolog/lib/cleaning.pl
+++ b/prolog/lib/cleaning.pl
@@ -1,0 +1,28 @@
+:- module(cleaning, [clean/2, unwrap/2, op(150, xfx, ...)]).
+
+clean(atomic(A), Res)
+ => Res = atomic(A).
+
+clean(L...U, Res)
+ => Res = L...U.
+
+clean(Expr, Expr1),
+    compound(Expr)
+ => mapargs(clean, Expr, Expr1).
+
+clean(A, Res),
+    atomic(A)
+ => Res = atomic(A).
+
+unwrap(atomic(A), Res)
+ => Res = A.
+
+unwrap(A...A, Res)
+ => Res = A.
+
+unwrap(A, Res),
+    compound(A)
+ => mapargs(unwrap, A, Res).
+
+unwrap(A, Res)
+ => Res = A.

--- a/prolog/lib/interface.pl
+++ b/prolog/lib/interface.pl
@@ -1,3 +1,5 @@
+:- use_module(cleaning).
+
 interval(Expr, Res) :-
     interval(Expr, Res, []).
 
@@ -13,30 +15,3 @@ default_digits(Dig, Flags)
     ; Dig1 = 2
     ),
     option(digits(Dig), Flags, Dig1). 
-
-clean(atomic(A), Res)
- => Res = atomic(A).
-
-clean(L...U, Res)
- => Res = L...U.
-
-clean(Expr, Expr1),
-    compound(Expr)
- => mapargs(clean, Expr, Expr1).
-
-clean(A, Res),
-    atomic(A)
- => Res = atomic(A).
-
-unwrap(atomic(A), Res)
- => Res = A.
-
-unwrap(A...A, Res)
- => Res = A.
-
-unwrap(A, Res),
-    compound(A)
- => mapargs(unwrap, A, Res).
-
-unwrap(A, Res)
- => Res = A.

--- a/prolog/lib/mcclass_op.pl
+++ b/prolog/lib/mcclass_op.pl
@@ -1,3 +1,5 @@
+:- use_module(cleaning).
+
 %
 % Addition (for testing)
 %
@@ -217,13 +219,16 @@ read(Options, A, Res, Flags) :-
 %
 % Assignment
 %
+r_hook('<-'/2).
 int_hook('<-', assign(_, _), _, [evaluate(false)]).
 assign(atomic(Var), A, Res, Flags) :-
-    interval_(A, Res, Flags),
-    ( Res = L ... _
-     -> r_mcclass:r_topic('<-'(Var, L)) % incomplete
-     ;  r_mcclass:r_topic('<-'(Var, Res))
-    ).
+    interval_(A, Res1, Flags),
+    unwrap(Res1, Res2),
+    ( Res2 = L ... _
+     -> eval('<-'(Var, L), Res3) % incomplete
+     ;  eval(('<-'(Var, Res2)), Res3)
+    ),
+    clean(Res3, Res).
 
 %
 % Other

--- a/prolog/lib/mcclass_op.pl
+++ b/prolog/lib/mcclass_op.pl
@@ -217,20 +217,6 @@ read(Options, A, Res, Flags) :-
     interval_(A + MEps...Eps, Res, New).
 
 %
-% Assignment
-%
-r_hook('<-'/2).
-int_hook('<-', assign(_, _), _, [evaluate(false)]).
-assign(atomic(Var), A, Res, Flags) :-
-    interval_(A, Res1, Flags),
-    unwrap(Res1, Res2),
-    ( Res2 = L ... _
-     -> eval('<-'(Var, L), Res3) % incomplete
-     ;  eval(('<-'(Var, Res2)), Res3)
-    ),
-    clean(Res3, Res).
-
-%
 % Other
 %
 int_hook(';', or(_, _), _, []).

--- a/prolog/lib/rint_op.pl
+++ b/prolog/lib/rint_op.pl
@@ -11,9 +11,22 @@ colon(A, A).
 %
 eval_hook(Atom, Res) :-
     atomic(Atom),
+    r_hook(R, Atom),
+    !,
+    call(R, Atom, Res).
+
+eval_hook(Atom, Res) :-
+    atomic(Atom),
     r_hook(Atom),
     !,
     r(Atom, Res).
+
+eval_hook(Expr, Res) :-
+    compound(Expr),
+    compound_name_arity(Expr, Name, Arity),
+    r_hook(R, Name/Arity),
+    !,
+    call(R, Expr, Res).
 
 eval_hook(Expr, Res) :-
     compound(Expr),

--- a/prolog/lib/rint_op.pl
+++ b/prolog/lib/rint_op.pl
@@ -339,3 +339,17 @@ dchisq_A(L...U, atomic(Df), Res, Flags) :-
     Mode is Df - 2,
     interval_(dchisq(atomic(Mode), atomic(Df)), U1..._, Flags),
     Res = L1...U1.
+
+%
+% Assignment
+%
+r_hook('<-'/2).
+int_hook('<-', assign(_, _), _, [evaluate(false)]).
+assign(atomic(Var), A, Res, Flags) :-
+    interval_(A, Res1, Flags),
+    unwrap(Res1, Res2),
+    ( Res2 = L ... _
+     -> eval('<-'(Var, L), Res3) % incomplete
+     ;  eval(('<-'(Var, Res2)), Res3)
+    ),
+    clean(Res3, Res).

--- a/prolog/mcclass.pl
+++ b/prolog/mcclass.pl
@@ -1,6 +1,7 @@
 :- module(mcint, [interval/2, interval/3, op(150, xfx, ...)]).
 
 :- multifile r_hook/1.
+:- multifile r_hook/2.
 :- multifile int_hook/4.
 :- multifile eval_hook/2.
 :- multifile mono/2.

--- a/prolog/rint.pl
+++ b/prolog/rint.pl
@@ -1,6 +1,7 @@
 :- module(rint, [interval/2, interval/3, op(150, xfx, ...)]).
 
 :- multifile r_hook/1.
+:- multifile r_hook/2.
 :- multifile int_hook/4.
 :- multifile eval_hook/2.
 :- multifile mono/2.


### PR DESCRIPTION
In addition to the main update involving r_hook/2 and eval_hook/2, I also moved the clean/2 and unwrap/2 predicates to a separate module, so that they can be used again in mcclass_op.pl, where they are needed for  the assignment. 