### PR TITLE
Added int_hook for r/1

### DIFF
--- a/prolog/lib/cleaning.pl
+++ b/prolog/lib/cleaning.pl
@@ -1,4 +1,4 @@
-:- module(cleaning, [clean/2, unwrap/2, op(150, xfx, ...)]).
+:- module(cleaning, [clean/2, unwrap/2, unwrap_r/2, op(150, xfx, ...)]).
 
 clean(atomic(A), Res)
  => Res = atomic(A).
@@ -26,3 +26,17 @@ unwrap(A, Res),
 
 unwrap(A, Res)
  => Res = A.
+
+unwrap_r(A, Res)
+ => unwrap_r_(A, Res).
+
+unwrap_r_(atomic(A), Res)
+ => Res = A.
+
+unwrap_r_(A, _Res),
+    A = _..._
+ => fail.
+
+unwrap_r_(A, Res),
+    compound(A)
+ => mapargs(unwrap_r_, A, Res).

--- a/prolog/lib/core.pl
+++ b/prolog/lib/core.pl
@@ -83,8 +83,7 @@ instantiate_(ci(A, B), Res),
     Res = ci(_, _)
  => Res = ci(A, B).
 
-instantiate_(A, Res),
-    var(Res)
+instantiate_(A, Res)
  => Res = A.
 
 % special case: multiplication ([*, *], commutative)

--- a/prolog/lib/rint_op.pl
+++ b/prolog/lib/rint_op.pl
@@ -1,5 +1,7 @@
 :- reexport('../r'), r_initialize.
 
+:- use_module(cleaning).
+
 %
 % Skip R vectors
 %
@@ -9,6 +11,13 @@ colon(A, A).
 %
 % Obtain atoms or functions from R
 %
+eval_hook(r(Expr), Res) :-
+    eval_hook(Expr, Res).
+
+eval_hook(r(Expr), Res) :-
+    !,
+    r(Expr, Res).
+
 eval_hook(Atom, Res) :-
     atomic(Atom),
     r_hook(R, Atom),
@@ -37,6 +46,19 @@ eval_hook(Expr, Res) :-
 
 r_hook(true).
 r_hook(false).
+
+%
+% Call R 
+%
+int_hook(r, r1(_), _, [evaluate(false)]).
+r1(A, Res, _Flags) :-
+    unwrap_r(A, A1),
+    eval_hook(r(A1), Res1),
+    Res = atomic(Res1),
+    !.
+
+r1(A, Res, Flags) :-
+    interval_(A, Res, Flags).
 
 %
 % Binomial distribution

--- a/prolog/lib/rint_op.pl
+++ b/prolog/lib/rint_op.pl
@@ -50,14 +50,23 @@ r_hook(false).
 %
 % Call R 
 %
-int_hook(r, r1(_), _, [evaluate(false)]).
-r1(A, Res, _Flags) :-
-    unwrap_r(A, A1),
-    eval_hook(r(A1), Res1),
-    Res = atomic(Res1),
-    !.
+int_hook(r, r1(atomic), _, [evaluate(false)]).
+r1(atomic(A), Res, _Flags) :-
+    eval_hook(r(A), Res1),
+    Res = atomic(Res1).
 
-r1(A, Res, Flags) :-
+int_hook(r, r2(_), _, [evaluate(false)]).
+r2(A, Res, Flags) :-
+    compound(A),
+    compound_name_arguments(A, Name, Args1),
+    maplist(interval__(Flags), Args1, Args2),
+    compound_name_arguments(A1, Name, Args2),
+    unwrap_r(A1, A2),
+    !,
+    eval_hook(r(A2), Res1),
+    Res = atomic(Res1).
+
+r2(A, Res, Flags) :-
     interval_(A, Res, Flags).
 
 %

--- a/test/test_rint.pl
+++ b/test/test_rint.pl
@@ -5,7 +5,27 @@
 :- use_module(library(rint)).
 
 test_rint :-
-    run_tests([binom, normal, t]).
+    run_tests([r, binom, normal, t]).
+
+:- begin_tests(r).
+
+test(r1) :-
+    A is 1,
+    interval(<-(x, A), _),
+    interval(r(x), Res),
+    Res = A.
+
+test(r2) :-
+    interval(r(1 + 1) + 2...3, Res),
+    Res = 4...5.
+
+test(r3) :-
+    interval(dbinom(1...2, 10, 0.7), L1...U1),
+    interval(r(dbinom(1...2, 10, 0.7)), L2...U2),
+    L1 =:= L2,
+    U1 =:= U2.
+
+:- end_tests(r).
 
 :- begin_tests(binom).
 


### PR DESCRIPTION
If Expr in r(Expr) does not contain intervals, R is called directly with that expression, otherwise interval_.

rint_op.pl:

```
int_hook(r, r1(_), _, [evaluate(false)]).
r1(A, Res, _Flags) :-
    unwrap_r(A, A1),
    eval_hook(r(A1), Res1),
    Res = atomic(Res1),
    !.

r1(A, Res, Flags) :-
    interval_(A, Res, Flags).
```


test_rint.pl:
```
:- begin_tests(r).

test(r1) :-
    A is 1,
    interval(<-(x, A), _),
    interval(r(x), Res),
    Res = A.

test(r2) :-
    interval(r(1 + 1) + 2...3, Res),
    Res = 4...5.

test(r3) :-
    interval(dbinom(1...2, 10, 0.7), L1...U1),
    interval(r(dbinom(1...2, 10, 0.7)), L2...U2),
    L1 =:= L2,
    U1 =:= U2.

:- end_tests(r).
```