### PR TITLE
Update <-/2 and update for mcclass

### DIFF
--- a/prolog/lib/ci.pl
+++ b/prolog/lib/ci.pl
@@ -1,11 +1,7 @@
-% For mcclass. Todo: change later 
-interval_(A, Res, _Flags),
-    atomic(A)
- => Res = atomic(A).
-
 interval_(atomic(A), Res, _Flags),
     r_hook(_R, A)
- => eval(A, Res). 
+ => eval(A, Res1),
+    clean(Res1, Res).
 
 interval_(C, Res, Flags),
     C = ci(A, B)

--- a/prolog/lib/mcclass_op.pl
+++ b/prolog/lib/mcclass_op.pl
@@ -1,5 +1,3 @@
-:- use_module(cleaning).
-
 %
 % Addition (for testing)
 %

--- a/prolog/lib/rint_op.pl
+++ b/prolog/lib/rint_op.pl
@@ -380,7 +380,7 @@ assign(atomic(Var), A, Res, Flags) :-
     interval_(A, Res1, Flags),
     unwrap(Res1, Res2),
     ( Res2 = L ... _
-     -> eval('<-'(Var, L), Res3) % incomplete
-     ;  eval(('<-'(Var, Res2)), Res3)
+     -> eval('<-'(Var, L), Res3)
+     ;  eval('<-'(Var, Res2), Res3)
     ),
     clean(Res3, Res).

--- a/prolog/lib/rint_op.pl
+++ b/prolog/lib/rint_op.pl
@@ -53,7 +53,7 @@ r_hook(false).
 int_hook(r, r1(atomic), _, [evaluate(false)]).
 r1(atomic(A), Res, _Flags) :-
     eval_hook(r(A), Res1),
-    Res = atomic(Res1).
+    clean(Res1, Res).
 
 int_hook(r, r2(_), _, [evaluate(false)]).
 r2(A, Res, Flags) :-
@@ -64,7 +64,7 @@ r2(A, Res, Flags) :-
     unwrap_r(A1, A2),
     !,
     eval_hook(r(A2), Res1),
-    Res = atomic(Res1).
+    clean(Res1, Res).
 
 r2(A, Res, Flags) :-
     interval_(A, Res, Flags).
@@ -376,11 +376,14 @@ dchisq_A(L...U, atomic(Df), Res, Flags) :-
 %
 r_hook('<-'/2).
 int_hook('<-', assign(_, _), _, [evaluate(false)]).
-assign(atomic(Var), A, Res, Flags) :-
-    interval_(A, Res1, Flags),
-    unwrap(Res1, Res2),
-    ( Res2 = L ... _
-     -> eval('<-'(Var, L), Res3)
-     ;  eval('<-'(Var, Res2), Res3)
-    ),
-    clean(Res3, Res).
+assign(Var, A, Res, Flags) :-
+    interval_(A, A1, Flags),
+    assign_(Var, A1, Res).
+
+assign_(atomic(Var), L...U, Res) :-
+    eval_hook(Var <- call("...", L, U), Res),
+    !.
+
+assign_(atomic(Var), atomic(A), Res) :-
+    eval_hook(Var <- A, Res1),
+    clean(Res1, Res).

--- a/prolog/lib/rint_op.pl
+++ b/prolog/lib/rint_op.pl
@@ -53,6 +53,7 @@ r_hook(false).
 int_hook(r, r1(atomic), _, [evaluate(false)]).
 r1(atomic(A), Res, _Flags) :-
     eval_hook(r(A), Res1),
+    !,
     clean(Res1, Res).
 
 int_hook(r, r2(_), _, [evaluate(false)]).

--- a/prolog/mcclass.pl
+++ b/prolog/mcclass.pl
@@ -1,4 +1,4 @@
-:- module(mcint, [interval/2, interval/3, op(150, xfx, ...)]).
+:- module(mcint, [interval/2, interval/3, op(150, xfx, ...), op(800, xfx, <-)]).
 
 :- multifile r_hook/1.
 :- multifile r_hook/2.

--- a/prolog/rint.pl
+++ b/prolog/rint.pl
@@ -1,4 +1,4 @@
-:- module(rint, [interval/2, interval/3, op(150, xfx, ...)]).
+:- module(rint, [interval/2, interval/3, op(150, xfx, ...), op(800, xfx, <-)]).
 
 :- multifile r_hook/1.
 :- multifile r_hook/2.

--- a/test/test_rint.pl
+++ b/test/test_rint.pl
@@ -5,7 +5,7 @@
 :- use_module(library(rint)).
 
 test_rint :-
-    run_tests([r, binom, normal, t]).
+    run_tests([r, assignment, binom, normal, t]).
 
 :- begin_tests(r).
 
@@ -26,6 +26,22 @@ test(r3) :-
     U1 =:= U2.
 
 :- end_tests(r).
+
+:- begin_tests(assignment).
+
+test(assign1) :-
+    A = 1,
+    interval(a <- A, _Res),
+    interval(r(a), Res),
+    Res =:= A.
+
+test(assign2) :-
+    A = 1...2,
+    interval(a <- A, _Res),
+    interval(r(a), Res),
+    Res = A.
+
+:- end_tests(assignment).
 
 :- begin_tests(binom).
 


### PR DESCRIPTION
1. <-/2 can be used as infix 
2.  <-/2 works with both simple numbers and intervals so that intervals can be stored as variables in R.

```
test(assign1) :-
    A = 1,
    interval(a <- A, _Res),
    interval(r(a), Res),
    Res =:= A.

test(assign2) :-
    A = 1...2,
    interval(a <- A, _Res),
    interval(r(a), Res),
    Res = A.
```

3. Updated ci.pl for mcclass

```
interval_(atomic(A), Res, _Flags),
    r_hook(_R, A)
 => eval(A, Res1),
    clean(Res1, Res).
```