### PR TITLE
Performance improvement

### DIFF
--- a/prolog/lib/ci.pl
+++ b/prolog/lib/ci.pl
@@ -9,6 +9,10 @@ interval_(C, Res, Flags),
     interval_(B, B1, Flags),
     Res = ci(A1, B1).
 
-instantiate(A, Res),
+instantiate(A, B),
     A = ci
- => Res = ci(_, _).
+ => B = ci(_, _).
+
+instantiate(A, B),
+    B = ci(_, _)
+ => A = ci.

--- a/prolog/lib/op.pl
+++ b/prolog/lib/op.pl
@@ -418,6 +418,12 @@ pow(L...U, atomic(Exp), Res, _Flags),
     natural(Exp)
  => eval(L^Exp, U^Exp, Res).
 
+pow(L...U, atomic(Exp), Res, _Flags),
+    positive(L, U),
+    Exp > 0,
+    Exp < 1
+ => eval(L^Exp, U^Exp, Res).
+
 % Utility
 even(A) :-
     A mod 2 =:= 0.

--- a/prolog/lib/op.pl
+++ b/prolog/lib/op.pl
@@ -86,14 +86,21 @@ not_eq(A...B, C...D, Res, Flags) :-
 
 not_eq(_..._, _..._, false, _Flags).
 
-int_hook(=:=, eq(..., ...), _, []).
-eq(A...B, C...D, Res, Flags) :-
+int_hook(=:=, eq1(atomic, atomic), _, []).
+eq1(atomic(A), atomic(B), true, _Flags) :-
+    A =:= B,
+    !.
+
+eq1(_, _, false, _Flags).
+
+int_hook(=:=, eq2(..., ...), _, []).
+eq2(A...B, C...D, Res, Flags) :-
     less_eq(A...B, C...D, true, Flags),
     great_eq(A...B, C...D, true, Flags),
     !,
     Res = true.
 
-eq(_..._, _..._, false, _Flags). 
+eq2(_..._, _..._, false, _Flags). 
 
 %
 % Division
@@ -106,6 +113,16 @@ int_hook(/, div2(..., ...), ..., []).
 div2(A...B, C...D, Res, Flags) :-
     !,
     div(A...B, C...D, Res, Flags).
+
+int_hook(/, div3(..., atomic), ..., []).
+div3(L...U, atomic(A), Res, Flags) :-
+    !,
+    div(L...U, A...A, Res, Flags).
+
+int_hook(/, div4(atomic, ...), ..., []).
+div4(atomic(A), L...U, Res, Flags) :-
+    !,
+    div(A...A, L...U, Res, Flags).
 
 % Hickey Figure 1
 mixed(L, U) :-

--- a/prolog/lib/rint_op.pl
+++ b/prolog/lib/rint_op.pl
@@ -44,9 +44,6 @@ eval_hook(Expr, Res) :-
     !,
     r(Expr, Res).
 
-r_hook(true).
-r_hook(false).
-
 %
 % Call R 
 %
@@ -91,8 +88,9 @@ r_hook(pbinom1/3).
 mono(pbinom1/3, [-, +, +]).
 
 %
-% Quantile function - hier weiter
+% Quantile function
 %
+int_hook(qbinom, qbinom(..., atomic, ..., atomic), ..., []).
 int_hook(qbinom, qbinom(..., ..., ..., atomic), ..., []).
 
 % lower tail
@@ -113,7 +111,15 @@ mono(qbinom1/3, [-, +, +]).
 %
 % Density
 %
+int_hook(dbinom, dbinom(..., atomic, atomic), ..., []).
+int_hook(dbinom, dbinom(..., atomic, ...), ..., []).
 int_hook(dbinom, dbinom(..., ..., ...), ..., []).
+
+dbinom(X1...X2, atomic(N), P1...P2, Res, Flags) :-
+    dbinom(X1...X2, N...N, P1...P2, Res, Flags).
+
+dbinom(X1...X2, atomic(N), atomic(P), Res, Flags) :-
+    dbinom(X1...X2, N...N, P...P, Res, Flags).
 
 % left to X / N
 dbinom(X1...X2, N1...N2, P1...P2, Res, Flags) :-
@@ -154,8 +160,8 @@ pnorm1(Z, Res, Flags) :-
      interval_(pnorm0(Z), Res, Flags).
 
 int_hook(pnorm, pnorm2(atomic), atomic, []).
-pnorm2(atomic(Z), atomic(Res), Flags) :-
-     eval(pnorm0(Z), Res, Flags).
+pnorm2(atomic(Z), atomic(Res), _Flags) :-
+     eval(pnorm0(Z), Res).
 
 %
 % Quantile function
@@ -173,8 +179,8 @@ qnorm1(P, Res, Flags) :-
      interval_(qnorm0(P), Res, Flags).
 
 int_hook(qnorm, qnorm2(atomic), atomic, []).
-qnorm2(atomic(P), atomic(Res), Flags) :-
-     eval(qnorm0(P), Res, Flags).
+qnorm2(atomic(P), atomic(Res), _Flags) :-
+     eval(qnorm0(P), Res).
 
 %
 % Density
@@ -209,6 +215,7 @@ dnorm0(A...B, Res, Flags) :-
 %
 % t distribution
 %
+int_hook(pt, pt(..., atomic, atomic), ..., []).
 int_hook(pt, pt(..., ..., atomic), ..., []).
 
 r_hook(pt0/2).
@@ -259,6 +266,7 @@ pt(L...U, Df, atomic(false), Res, Flags) :-
 r_hook(qt0/2).
 mono(qt0/2, [+,-]).
 
+int_hook(qt, qt(..., atomic), ..., []).
 int_hook(qt, qt(..., ...), ..., []).
 qt(P, Df, Res, Flags) :-
     interval_(qt0(P, Df), Res, Flags).
@@ -272,6 +280,7 @@ mono(dt0/2, [+, +]).
 r_hook(dt1/2).
 mono(dt1/2, [-, +]).
 
+int_hook(dt, dt(..., atomic), ..., []).
 int_hook(dt, dt(..., ...), ..., []).
 dt(L...U, Df, Res, Flags) :-
     U =< 0,
@@ -291,7 +300,6 @@ dt(L...U, Df, Res, Flags) :-
 %
 % chisq
 %
-
 int_hook(pchisq, pchisq(..., atomic, atomic), ..., []).
 
 r_hook(pchisq0/2).

--- a/test/performance/performance_log.txt
+++ b/test/performance/performance_log.txt
@@ -12,41 +12,15 @@ test9 | Inferences: 75763 | Levels=9
 ---------
 
 ---------
-2025-03-03 14:29:42 
-test1 | Inferences: 1240
-test2 | Inferences: 1303
-test3 | Inferences: 766
-test4 | Inferences: 870
-test5 | Inferences: 139
+2025-03-05 10:08:37 
+test1 | Inferences: 1613
+test2 | Inferences: 1399
+test3 | Inferences: 814
+test4 | Inferences: 918
+test5 | Inferences: 171
 test6 | Inferences: 726 | Levels=6
 test7 | Inferences: 844 | Levels=7
 test8 | Inferences: 962 | Levels=8
 test9 | Inferences: 1080 | Levels=9
----------
-
----------
-2025-03-03 14:30:24 
-test1 | Inferences: 1240
-test2 | Inferences: 1303
-test3 | Inferences: 766
-test4 | Inferences: 870
-test5 | Inferences: 139
-test6 | Inferences: 726 | Levels=6
-test7 | Inferences: 844 | Levels=7
-test8 | Inferences: 962 | Levels=8
-test9 | Inferences: 2378 | Levels=20
----------
-
----------
-2025-03-03 14:31:03 
-test1 | Inferences: 1240
-test2 | Inferences: 1303
-test3 | Inferences: 766
-test4 | Inferences: 870
-test5 | Inferences: 139
-test6 | Inferences: 726 | Levels=6
-test7 | Inferences: 844 | Levels=7
-test8 | Inferences: 962 | Levels=8
-test9 | Inferences: 118018 | Levels=1000
 ---------
 

--- a/test/performance/performance_log.txt
+++ b/test/performance/performance_log.txt
@@ -11,3 +11,42 @@ test8 | Inferences: 37862 | Levels=8
 test9 | Inferences: 75763 | Levels=9
 ---------
 
+---------
+2025-03-03 14:29:42 
+test1 | Inferences: 1240
+test2 | Inferences: 1303
+test3 | Inferences: 766
+test4 | Inferences: 870
+test5 | Inferences: 139
+test6 | Inferences: 726 | Levels=6
+test7 | Inferences: 844 | Levels=7
+test8 | Inferences: 962 | Levels=8
+test9 | Inferences: 1080 | Levels=9
+---------
+
+---------
+2025-03-03 14:30:24 
+test1 | Inferences: 1240
+test2 | Inferences: 1303
+test3 | Inferences: 766
+test4 | Inferences: 870
+test5 | Inferences: 139
+test6 | Inferences: 726 | Levels=6
+test7 | Inferences: 844 | Levels=7
+test8 | Inferences: 962 | Levels=8
+test9 | Inferences: 2378 | Levels=20
+---------
+
+---------
+2025-03-03 14:31:03 
+test1 | Inferences: 1240
+test2 | Inferences: 1303
+test3 | Inferences: 766
+test4 | Inferences: 870
+test5 | Inferences: 139
+test6 | Inferences: 726 | Levels=6
+test7 | Inferences: 844 | Levels=7
+test8 | Inferences: 962 | Levels=8
+test9 | Inferences: 118018 | Levels=1000
+---------
+


### PR DESCRIPTION
This major update turns the module's run-time complexity from exponential to linear, as shown here:


**Before**:
```
---------
2025-02-27 16:29:02 
test1 | Inferences: 4209
test2 | Inferences: 4270
test3 | Inferences: 916
test4 | Inferences: 1769
test5 | Inferences: 166
test6 | Inferences: 9420 | Levels=6
test7 | Inferences: 18905 | Levels=7
test8 | Inferences: 37862 | Levels=8
test9 | Inferences: 75763 | Levels=9
---------
```

**After:**
```
---------
2025-03-05 10:08:37 
test1 | Inferences: 1613
test2 | Inferences: 1399
test3 | Inferences: 814
test4 | Inferences: 918
test5 | Inferences: 171
test6 | Inferences: 726 | Levels=6
test7 | Inferences: 844 | Levels=7
test8 | Inferences: 962 | Levels=8
test9 | Inferences: 1080 | Levels=9
---------
```

Until now, the issue was that it would first look for a hook, then evaluate all the arguments of the expression and then check if they match the type definition in the hook. This means that the evaluation occurred for each hook.

**Before**
```
interval_(Expr, Res, Flags),
    compound(Expr),
    compound_name_arguments(Expr, Name, Args),
    int_hook(Name, Mask, Res0, Opt),
    option(evaluate(true), Opt, true),
    instantiate(Res0, Res),
    compound_name_arguments(Mask, Fun, Args1),
    maplist(instantiate, Args1, Args2),
    maplist(interval__(Flags), Args, Args2)
 => compound_name_arguments(Goal, Fun, Args2),
    call(Goal, Res, Flags).

```

Now, instead, the arguments are evaluated once and afterwards the hooks are successively tried out.

**After**
```
% Evaluate arguments
interval_(Expr, Res, Flags),
    compound(Expr),
    compound_name_arguments(Expr, Name, Args),
    maplist(interval__(Flags), Args, Args1),
    compound_name_arguments(Expr1, Name, Args1)
 => interval2_(Expr1, Res, Flags).

% Find int_hook
interval2_(Expr, Res, Flags),
    compound(Expr),
    compound_name_arguments(Expr, Name, Args),
    maplist(instantiate, Types, Args),
    int_hook(Name, Mask, Res0, _Opt),
    compound_name_arguments(Mask, Fun, Types),
    compound_name_arguments(Goal, Fun, Args),
    findall(Res1, call(Goal, Res1, Flags), Sol),
    maplist(instantiate(Res0), Sol)
 => member(Res, Sol).
```

I also added the feature that it checks whether the type of the result matches the one in the hook. Although the hooks already had an argument for the result type, this was not working properly until now, because it could not backtrack to pick another hook in case of a missing match in the return type.

I also had to add some hooks, because now it does not automatically transform an atom into an interval if there is only a hook for intervals and not atoms.

But the tests all pass and I did not touch those, and McClass (aka Mistakes) works too.

The PR could unfortunately not be smaller, if everything so far is to work properly.