### PR TITLE
Added bug argument to omit_left/2 and omit_right/2

### DIFF
--- a/prolog/lib/mcclass_op.pl
+++ b/prolog/lib/mcclass_op.pl
@@ -51,13 +51,13 @@ pval(A, Res, Flags) :-
 % Bugs
 %
 % Forget parts of an expression
-int_hook(omit_left, left(_), _, [evaluate(false)]).
-left(A, Res, Flags) :-
+int_hook(omit_left, left(_, _), _, [evaluate(false)]).
+left(_Bug, A, Res, Flags) :-
     A =.. [_Op, _L, R],
     interval_(R, Res, Flags).
 
-int_hook(omit_right, right(_), _, [evaluate(false)]).
-right(A, Res, Flags) :-
+int_hook(omit_right, right(_, _), _, [evaluate(false)]).
+right(_Bug, A, Res, Flags) :-
     A =.. [_Op, L, _R],
     interval_(L, Res, Flags).
 
@@ -75,12 +75,12 @@ instead2(_Bug, Wrong, _Correct, _Correct0, Res, Flags) :-
 
 % Drop
 int_hook(drop_right, drop_right(_, _), _, [evaluate(false)]).
-drop_right(_Bug, A, Res, Flags) :-
-    right(A, Res, Flags).
+drop_right(Bug, A, Res, Flags) :-
+    right(Bug, A, Res, Flags).
 
 int_hook(drop_left, drop_left(_, _), _, [evaluate(false)]).
-drop_left(_Bug, A, Res, Flags) :-
-    left(A, Res, Flags).
+drop_left(Bug, A, Res, Flags) :-
+    left(Bug, A, Res, Flags).
 
 % add_left, add_right
 int_hook(add_right, add(_, _), _, [evaluate(false)]).

--- a/test/test_mcclass.pl
+++ b/test/test_mcclass.pl
@@ -88,27 +88,31 @@ test(pval_interval) :-
 :- begin_tests(bugs).
 
 test(omit_right_atomic) :-
+    Bug = bug1,
     A = 5,
     B = 4,
-    interval(omit_right(A - B), Res),
+    interval(omit_right(Bug, A - B), Res),
     Res = A.
 
 test(omit_right_interval) :-
+    Bug = bug1,
     A = 11...12,
     B = 20...21,
-    interval(omit_right(A - B), Res),
+    interval(omit_right(Bug, A - B), Res),
     Res = A.
 
 test(omit_left_atomic) :-
+    Bug = bug1,
     A = 5,
     B = 4,
-    interval(omit_left(A - B), Res),
+    interval(omit_left(Bug, A - B), Res),
     Res = B.
 
 test(omit_left_interval) :-
+    Bug = bug1,
     A = 11...12,
     B = 20...21,
-    interval(omit_left(A - B), Res),
+    interval(omit_left(Bug, A - B), Res),
     Res = B.
 
 test(omit) :-


### PR DESCRIPTION
I am working on that issues in McClass that only about 20 of the original 52 buggy rules are being shown. 

This was one issue: we had omit_right/1 and omit_left/2 without the argument for the bug name.