### PR TITLE
Minor changes

### DIFF
--- a/prolog/lib/cleaning.pl
+++ b/prolog/lib/cleaning.pl
@@ -1,4 +1,4 @@
-:- module(cleaning, [clean/2, unwrap/2, unwrap_r/2, op(150, xfx, ...)]).
+:- module(cleaning, [clean/2, unwrap/2, return/3, unwrap_r/2, op(150, xfx, ...)]).
 
 clean(atomic(A), Res)
  => Res = atomic(A).
@@ -40,3 +40,10 @@ unwrap_r_(A, _Res),
 unwrap_r_(A, Res),
     compound(A)
  => mapargs(unwrap_r_, A, Res).
+
+ return(L, U, Res),
+    L =:= U
+ => Res = atomic(L).
+
+return(L, U, Res)
+ => Res = L...U. 

--- a/prolog/lib/core.pl
+++ b/prolog/lib/core.pl
@@ -115,13 +115,6 @@ interval2_(_, _, _Flags)
 interval_(_, _, _Flags)
  => fail.
 
-return(L, U, Res),
-    L =:= U
- => Res = atomic(L).
-
-return(L, U, Res)
- => Res = L...U. 
-
 lower(Dir, Name, Args, Res) :-
     maplist(lower, Dir, Args, Lower),
     Expr =.. [Name | Lower],

--- a/prolog/lib/core.pl
+++ b/prolog/lib/core.pl
@@ -103,8 +103,8 @@ interval2_(Expr, Res, _Flags),
     findall(R, lower(Dir, Name, Args, R), Lower),
     min_list(Lower, L),
     findall(R, upper(Dir, Name, Args, R), Upper),
-    max_list(Upper, U),
-    Res = L...U.
+    max_list(Upper, U),  
+    return(L, U, Res).
 
 %
 % Default case
@@ -114,6 +114,13 @@ interval2_(_, _, _Flags)
 
 interval_(_, _, _Flags)
  => fail.
+
+return(L, U, Res),
+    L =:= U
+ => Res = atomic(L).
+
+return(L, U, Res)
+ => Res = L...U. 
 
 lower(Dir, Name, Args, Res) :-
     maplist(lower, Dir, Args, Lower),

--- a/prolog/lib/mcclass_op.pl
+++ b/prolog/lib/mcclass_op.pl
@@ -101,7 +101,7 @@ dot(A, B, Res, Flags) :-
 %
 int_hook(available, avail1(atomic), _, []).
 avail1(atomic(A), Res, _Flags) :-
-    avail2(atomic(A), Res),
+    avail2(atomic(A), _Res1),
     !,
     Res = true 
     ;   Res = false.

--- a/prolog/lib/rint_op.pl
+++ b/prolog/lib/rint_op.pl
@@ -215,6 +215,7 @@ dnorm0(A...B, Res, Flags) :-
 %
 % t distribution
 %
+int_hook(pt, pt_(..., atomic), ..., []).
 int_hook(pt, pt(..., atomic, atomic), ..., []).
 int_hook(pt, pt(..., ..., atomic), ..., []).
 
@@ -229,6 +230,10 @@ mono(pt2/2, [-,+]).
 
 r_hook(pt3/2).
 mono(pt3/2, [-,-]).
+
+% default (lower tail)
+pt_(A, Df, Res, Flags) :-
+    pt(A, Df, atomic(true), Res, Flags).
 
 % lower tail
 pt(L...U, Df, atomic(true), Res, Flags) :-

--- a/test/test_rint.pl
+++ b/test/test_rint.pl
@@ -123,6 +123,10 @@ test(dnorm_z_mixed) :-
 
 :- begin_tests(t).
 
+test(pt_default_tail) :-
+    interval(pt(-0.5... -0.2, 5), Res),
+    equal(Res, 0.3191...0.4247).
+
 test(pt_lowertail_neg) :-
     interval(pt(-0.5... -0.2, 5, true), Res),
     equal(Res, 0.3191...0.4247).


### PR DESCRIPTION
Further changes for that issue in McClass not showing all the buggy rules.

1) Added pt/2 with default tail

```
pt_(A, Df, Res, Flags) :-
    pt(A, Df, atomic(true), Res, Flags).
```

2) Avoid creation of interval if L == U. This was causing issues with functions having only 'atomic' in the declaration.

```
% General case 
interval2_(Expr, Res, _Flags),
    compound(Expr),
    compound_name_arity(Expr, Name, Arity),
    mono(Name/Arity, Dir)
 => compound_name_arguments(Expr, Name, Args),
    findall(R, lower(Dir, Name, Args, R), Lower),
    min_list(Lower, L),
    findall(R, upper(Dir, Name, Args, R), Upper),
    max_list(Upper, U),  
    return(L, U, Res).
```

cleaning.pl
```
return(L, U, Res),
    L =:= U
 => Res = atomic(L).

return(L, U, Res)
 => Res = L...U. 
```

3) Fixed error for available/1. This was not evident before, because the hook with 'atomic' was actually never used.
```

%
% Available: not NA
%
int_hook(available, avail1(atomic), _, []).
avail1(atomic(A), Res, _Flags) :-
    avail2(atomic(A), _Res1),
    !,
    Res = true 
    ;   Res = false.
```