### PR TITLE
Fix :/2 (R vectors)

### DIFF
--- a/inst/prolog/lib/rint_op.pl
+++ b/inst/prolog/lib/rint_op.pl
@@ -1,12 +1,6 @@
 :- use_module(cleaning).
 
 %
-% Skip R vectors
-%
-int_hook(:, colon(_, _), _, []).
-colon(A, A).
-
-%
 % Obtain atoms or functions from R
 %
 eval_hook(r(Expr), Res) :-
@@ -64,6 +58,13 @@ r2(A, Res, Flags) :-
 
 r2(A, Res, Flags) :-
     interval_(A, Res, Flags).
+
+%
+% Skip R vectors
+%
+int_hook(:, colon(_, _), _, []).
+colon(A, B, Res, _Flags) :-
+    Res =.. [:, A, B].
 
 %
 % Binomial distribution

--- a/test/test_rint.pl
+++ b/test/test_rint.pl
@@ -5,7 +5,7 @@
 :- use_module(library(rint)).
 
 test_rint :-
-    run_tests([r, assignment, binom, normal, t, chisq]).
+    run_tests([r, assignment, colon, binom, normal, t, chisq]).
 
 :- begin_tests(r).
 
@@ -42,6 +42,14 @@ test(assign2) :-
     Res = A.
 
 :- end_tests(assignment).
+
+:- begin_tests(colon).
+
+test(colon1) :-
+    A = 1:10,
+    interval(A, A).
+
+:- end_tests(colon).
 
 :- begin_tests(binom).
 


### PR DESCRIPTION
I became aware of this while debugging subgroups in McClass, where there is the interaction term "sex:therapy".

### Before:

![grafik](https://github.com/user-attachments/assets/f5e15f8b-0b95-47f1-8b33-2a6b9d462caa)


### After:

![grafik](https://github.com/user-attachments/assets/8eecc218-266e-49d6-b4c1-84dbc93eae58)




