### PR TITLE
Optimize clause order interval_/3

### DIFF
--- a/inst/prolog/lib/default.pl
+++ b/inst/prolog/lib/default.pl
@@ -1,0 +1,24 @@
+/** <file> Default
+
+Contains the default interval_/3 clause for nested expressions, 
+e.g., interval(5 + (1...2 - 1), Res). This is stored here in a separate file 
+to ensure more flexibility.
+**/
+
+interval_(A0, Res, Flags) :-
+    compound(A0),
+    compound_name_arguments(A0, Name, Args0),
+    maplist(interval__(Flags), Args0, Args1),
+    compound_name_arguments(A1, Name, Args1),
+    dif(A0, A1), 
+    !, interval_(A1, Res, Flags).
+
+interval_(A, _Res, _Flags) :-
+    !, 
+    term_string(A, String),
+    string_concat("No rule matches ", String, Message),
+    writeln(Message),
+    fail.
+
+interval__(Flags, A, Res) :-
+    interval_(A, Res, Flags).

--- a/inst/prolog/lib/op.pl
+++ b/inst/prolog/lib/op.pl
@@ -639,24 +639,3 @@ macro(max/2, all, [+, +]).
 % Min/2
 %
 macro(min/2, all, [+, +]).
-
-%
-% Evaluation of arguments.
-%
-interval_(A0, Res, Flags) :-
-    compound(A0),
-    compound_name_arguments(A0, Name, Args0),
-    maplist(interval__(Flags), Args0, Args1),
-    compound_name_arguments(A1, Name, Args1),
-    dif(A0, A1), 
-    !, interval_(A1, Res, Flags).
-
-interval_(A, _Res, _Flags) :-
-    !, 
-    term_string(A, String),
-    string_concat("No rule matches ", String, Message),
-    writeln(Message),
-    fail.
-
-interval__(Flags, A, Res) :-
-    interval_(A, Res, Flags).

--- a/prolog/interval.pl
+++ b/prolog/interval.pl
@@ -37,5 +37,6 @@ The choice of using consult and not the module system is motivated by need for m
 
 :- consult(['../inst/prolog/lib/interface', 
             '../inst/prolog/lib/op', 
+            '../inst/prolog/lib/default',
             '../inst/prolog/lib/eval',
             '../inst/prolog/lib/utility']).

--- a/prolog/rint.pl
+++ b/prolog/rint.pl
@@ -68,9 +68,10 @@ For general information on the use of interval/2 and interval/3, please refer to
 
 :- nb_setval(digits, 2).
 
-:- consult(['../inst/prolog/lib/interface', 
-            '../inst/prolog/lib/rint_op', 
+:- consult(['../inst/prolog/lib/interface',
             '../inst/prolog/lib/op', 
+            '../inst/prolog/lib/rint_op', 
+            '../inst/prolog/lib/default', 
             '../inst/prolog/lib/eval_r',
             'r', 
             '../inst/prolog/lib/utility']).


### PR DESCRIPTION
This is to avoid unnecessary backtracking with non-R functions.